### PR TITLE
multi-segment query support

### DIFF
--- a/lib/cjson/cjson.cpp
+++ b/lib/cjson/cjson.cpp
@@ -861,6 +861,8 @@ bool cjson::isNull() const
 
 int64_t cjson::getInt() const
 {
+	if (!nodeData)
+		return 0;
 	return nodeData->asInt;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,23 +21,24 @@ void StartOpenSet(openset::config::CommandlineArgs args)
 {
 
 #ifdef _MSC_VER
-
 	// Goofy windows socket subsystem init. 
 	// We shouldn't have to call this nowadays Microsoft
 	WSADATA wsaData;
 	const auto wVersionRequested = MAKEWORD(2, 0);
 	const auto err = WSAStartup(wVersionRequested, &wsaData);
+
 	if (err != 0) {
 		cout << "! could not initialize sockets." << endl;
 		exit(1);
 	}
 
+	// Set colors windows style
 	SetConsoleCP(CP_UTF8);
 	SetConsoleOutputCP(CP_UTF8);
 	SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), 12);
 #endif		
 
-auto banner = R"banner(
+	const auto banner = R"banner(
   _______  _______  _______  __    _  _______  _______  _______ 
  |       ||       ||       ||  \  | ||       ||       ||       |
  |   _   ||    _  ||    ___||   \ | ||  _____||    ___||_     _|
@@ -75,7 +76,6 @@ auto banner = R"banner(
 	service->start();
 
 }
-
 
 int main(int argc, char* argv[])
 {

--- a/src/oloop_count.cpp
+++ b/src/oloop_count.cpp
@@ -47,9 +47,9 @@ OpenLoopCount::~OpenLoopCount()
 
 void OpenLoopCount::storeResult(std::string name, int64_t count) const
 {
-	auto nameHash = MakeHash(name);
+	const auto nameHash = MakeHash(name);
 
-	auto set_cb = [count](openset::result::Accumulator* resultColumns)
+	const auto set_cb = [count](openset::result::Accumulator* resultColumns)
 	{
 		if (resultColumns->columns[0].value == NULLCELL)
 			resultColumns->columns[0].value = count;
@@ -90,7 +90,7 @@ void OpenLoopCount::storeSegments()
 		if (macro.second.segmentTTL != -1 && 
 			segmentWasCached.count(segmentName) == 0)
 		{
-			auto bits = resultBits[segmentName];
+			const auto bits = resultBits[segmentName];
 
 			if (!bits) continue;
 
@@ -101,8 +101,7 @@ void OpenLoopCount::storeSegments()
 			parts->attributes.swap(COL_SEGMENT, MakeHash(segmentName), bits);
 			delete bits; // we are done with the bits
 			resultBits[segmentName] = nullptr; // remove it from the map so it doesn't get deleted in ~OpenLoopCount
-
-
+			
 			parts->setSegmentTTL(segmentName, macro.second.segmentTTL);
 			parts->setSegmentRefresh(segmentName, macro.second.segmentRefresh);
 		}

--- a/src/querycommon.h
+++ b/src/querycommon.h
@@ -910,6 +910,7 @@ namespace openset
 		using HintPair = pair<string, HintOpList>;
 		using HintPairs = vector<HintPair>;
 		using ParamVars = unordered_map<string, cvar>;
+		using SegmentList = vector<std::string>;
 
 		// struct containing compiled macro
 		struct macro_s
@@ -921,6 +922,7 @@ namespace openset
 			string segmentName;
 			int64_t segmentTTL;
 			int64_t segmentRefresh;
+			SegmentList segments;
 
 			bool useGlobals; // uses global for table
 			bool useCached; // for segments allow use of cached values within TTL

--- a/src/queryinterpreter.h
+++ b/src/queryinterpreter.h
@@ -105,6 +105,10 @@ namespace openset
 			int nestDepth{ 0 }; // how many nested loops are we in
 			int breakDepth{ 0 }; // how many nested loops do we want to break
 
+			// column offsets and indexes used for queries with segments
+			int segmentColumnShift{ 0 };
+			std::vector<IndexBits*> segmentIndexes;
+
 			// row match values
 			int64_t matchStampTop{ 0 };
 			vector<int64_t> matchStampPrev{ 0 };
@@ -158,6 +162,8 @@ namespace openset
 					rowStamp <= compStamp + milliseconds);
 			}
 
+			SegmentList* getSegmentList() const;
+
 			void marshal_tally(int paramCount, col_s* columns, int currentRow);
 
 			void marshal_schedule(int paramCount);
@@ -191,6 +197,7 @@ namespace openset
 			void setGetSegmentCB(function<IndexBits*(string, bool& deleteAfterUsing)> cb);
 			// where our result bits are going to end up
 			void setBits(IndexBits* indexBits, int maxPopulation);
+			void setCompareSegments(IndexBits* querySegment, std::vector<IndexBits*> segments);
 
 			// reset class cvariables before running
 			// check for firstrun, check for globals.

--- a/src/queryparser.cpp
+++ b/src/queryparser.cpp
@@ -570,6 +570,17 @@ int64_t QueryParser::extractBlocks(int indent, FirstPass& lines, BlockList& bloc
 				}
 				blocks.pop_back();
 			}
+			else if (line.parts[0] == "segments")
+			{
+				for (auto& c : capture)
+				{
+					if (!c.parts.size())
+						continue;
+
+					vars.segmentNames.emplace_back(c.parts[0]);
+				}
+				blocks.pop_back();
+			}
 			else if (line.parts[0] == "def")
 			{
 				++blockCounter;
@@ -3740,6 +3751,7 @@ bool QueryParser::compileQuery(const char* query, Columns* columnsPtr, macro_s& 
 			macros.indexes.emplace_back(hintPair);
 		}
 
+		macros.segments = std::move(vars.segmentNames); // move these over, these are evaluated at run-time
 		macros.segmentTTL = segmentTTL;
 		macros.segmentRefresh = segmentRefresh;
 		macros.useCached = segmentUseCached;

--- a/src/queryparser.h
+++ b/src/queryparser.h
@@ -159,7 +159,7 @@ namespace openset
 					isString(false),
 					lambda(-1),
 					deferredInt(0)
-				{ }
+				{}
 
 				MiddleOp_s(opCode_e op, int64_t value, Debug_s& debugCopy, int64_t lambda = -1) :
 					op(op),
@@ -205,14 +205,11 @@ namespace openset
 				{}
 			};
 
-			using MiddleBlockList = vector<MiddleBlock_s>;
-
-			using VarMap = unordered_map<string, variable_s>;
-
-			using LiteralsMap = unordered_map<string, int>;
-
+			using MiddleBlockList = vector<MiddleBlock_s>;	
+			using VarMap = unordered_map<std::string, variable_s>;
+			using LiteralsMap = unordered_map<std::string, int>;
 			using HintList = std::vector<std::string>; // this will probably get fancier 
-			using HintMap = unordered_map<string, LineParts>;
+			using HintMap = unordered_map<std::string, LineParts>;
 
 			// structure for variables
 			struct middleVariables_s
@@ -222,6 +219,7 @@ namespace openset
 				VarMap columnVars;
 				VarMap groupVars;
 				SortList sortOrder;
+				SegmentList segmentNames;
 				LiteralsMap literals;
 			};
 
@@ -230,7 +228,7 @@ namespace openset
 			int blockCounter;
 
 			HintList hintNames;
-			HintMap hintMap;
+			HintMap hintMap;			
 
 			Columns* tableColumns;
 

--- a/src/result.h
+++ b/src/result.h
@@ -121,7 +121,6 @@ namespace std
 				hash = (hash << count) + key.key[1];
 			}
 			return hash;
-			//return MakeHash(recast<const char*>(key.key), sizeof(int64_t) * OpenSet::result::RowKey::keyDepth);
 		}
 	};
 }
@@ -134,15 +133,14 @@ namespace openset
 		struct accumulation_s
 		{
 			int64_t value;
-			//int64_t distinctId;
-			int count;
+			int32_t count;
 		};
 
-		const int accDepth = 16;
+		const int ACCUMULATOR_DEPTH = 16;
 
 		struct Accumulator
 		{
-			accumulation_s columns[accDepth];
+			accumulation_s columns[ACCUMULATOR_DEPTH];
 
 			Accumulator()
 			{
@@ -190,11 +188,11 @@ namespace openset
 			// a lock, whereas this does not, we will merge them after.
 			void addLocalText(int64_t hashId, cvar &value)
 			{
-				auto textPair = localText.get(hashId);
+				const auto textPair = localText.get(hashId);
 
 				if (!textPair)
 				{
-					auto textPtr = mem.newPtr(value.getString().length() + 1);
+					const auto textPtr = mem.newPtr(value.getString().length() + 1);
 					strcpy(textPtr, value.getString().c_str());
 					localText.set(hashId, textPtr);
 				}
@@ -202,11 +200,11 @@ namespace openset
 
 			void addLocalText(int64_t hashId, const std::string &value)
 			{
-				auto textPair = localText.get(hashId);
+				const auto textPair = localText.get(hashId);
 
 				if (!textPair)
 				{
-					auto textPtr = mem.newPtr(value.length() + 1);
+					const auto textPtr = mem.newPtr(value.length() + 1);
 					strcpy(textPtr, value.c_str());
 					localText.set(hashId, textPtr);
 				}
@@ -214,11 +212,11 @@ namespace openset
 
 			void addLocalText(int64_t hashId, char* value, int32_t length)
 			{
-				auto textPair = localText.get(hashId);
+				const auto textPair = localText.get(hashId);
 
 				if (!textPair)
 				{
-					auto textPtr = mem.newPtr(length + 1);
+					const auto textPtr = mem.newPtr(length + 1);
 					memcpy(textPtr, value, length);
 					textPtr[length] = 0;
 					localText.set(hashId, textPtr);


### PR DESCRIPTION
Allows you to add segments to queries:
```
segments:
     segment_1
     segment_2
```
This has the effect of running the query multiple times (but intelligently, the person record will only be mounted once). Note, that you can apply a single segment to a query, by simply providing one segment under `segments:`.  

The result set will contain additional column arrays (one for each segment):
```
{
	"g": "photo",
	"c": [56, 734, 0, 0, 734],
	"c2": [59539, 336516, 0, 0, 336516]
}
```
The first column set is simply named `c` as it would be in a non-segmented query, this lets it be compatible with any code expecting a regular result. Subsequent columns are enumerated starting at 2, so `c2`, `c3`, etc.