### PR TITLE
string functions, const fixes

### DIFF
--- a/lib/cjson/cjson.cpp
+++ b/lib/cjson/cjson.cpp
@@ -1512,6 +1512,9 @@ cjson* cjson::ParseBranch(cjson* N, char* & readPtr, bool embedding)
 						case 'v':
 							accumulator += '\v';
 							break;
+						case '/':
+							accumulator += '/';
+							break;
 						case '\\':
 							accumulator += '\\';
 							break;

--- a/lib/include/libcommon.h
+++ b/lib/include/libcommon.h
@@ -50,5 +50,5 @@
 #define SAFE_DELETE_ARRAY(x) { if(x != NULL) { delete [] x; x = NULL; } }
 #define SAFE_DELETE_VECTOR_POINTERS( type, vector ) { type* ptr; while ( ! vector.empty() ) { ptr = vector.back(); SAFE_DELETE( ptr ); vector.pop_back(); } }
 
-const int64_t NULLCELL = LLONG_MIN; // huge negative number, allows for memset 0xFE to clear large structs
+const int64_t NONE = LLONG_MIN; // huge negative number, allows for memset 0xFE to clear large structs
 const int64_t NOVALUE = LLONG_MAX;

--- a/lib/var/var.h
+++ b/lib/var/var.h
@@ -122,6 +122,10 @@ public:
 		REF
 	};
 
+	using List = std::vector<cvar>;
+	using Dict = std::unordered_map<cvar, cvar>;
+	using Set = std::unordered_set<cvar>;
+
 private:
 
 	union dataUnion
@@ -138,10 +142,6 @@ private:
 	dataUnion lastValue = {0}; // used as temporary buffer during conversion so we don't overwrite originals
 
 	std::string valueString;
-
-	using List = std::vector<cvar>;
-	using Dict = std::unordered_map<cvar, cvar>;
-	using Set = std::unordered_set<cvar>;
 
 	mutable List* listValue = nullptr;
 	mutable Dict* dictValue = nullptr;
@@ -217,7 +217,7 @@ public:
 	// so you can go:
 	// cvar mycvar = 5;
 
-	cvar(valueType type):
+	cvar(const valueType type):
 		type(type)
 	{
 		switch (type)
@@ -235,27 +235,25 @@ public:
 		}
 	}
 
-	cvar(int val) :
+	cvar(const int val) :
 		type(valueType::INT32)
 	{
-		value.asInt64 = 0;
 		value.asInt32 = val;
 	}
 
-	cvar(int64_t val) :
+	cvar(const int64_t val) :
 		type(valueType::INT64)
 	{
 		value.asInt64 = val;
 	}
 
-	cvar(float val) :
+	cvar(const float val) :
 		type(valueType::FLT)
 	{
-		value.asInt64 = 0;
 		value.asFloat = val;
 	}
 
-	cvar(double val) :
+	cvar(const double val) :
 		type(valueType::DBL)
 	{
 		value.asDouble = val;
@@ -267,21 +265,20 @@ public:
 		valueString.assign(val);
 	}
 
-	cvar(std::string val) :
+	cvar(const std::string val) :
 		type(valueType::STR)
 	{
 		value.asInt64 = -1;
 		valueString = val;
 	}
 
-	cvar(bool val) :
+	cvar(const bool val) :
 		type(valueType::BOOL)
 	{
-		value.asInt64 = 0;
 		value.asBool = val;
 	}
 			
-	cvar(std::vector<cvar> val) :
+	cvar(const std::vector<cvar> val) :
 		type(valueType::LIST)
 	{
 		listValue = new List();
@@ -306,7 +303,7 @@ public:
 	cvar(const std::initializer_list<std::pair<cvar,cvar>> &source)
 	{
 		dict();
-		for (auto item : source)
+		for (const auto item : source)
 			(*dictValue)[cvar{ item.first }] = cvar{ item.second };
 	}
 
@@ -326,7 +323,7 @@ public:
 		*this = static_cast<int64_t>(LLONG_MIN);
 	}
 
-	bool isNone()
+	bool isNone() const
 	{
 		return *this == static_cast<int64_t>(LLONG_MIN);
 	}
@@ -458,7 +455,7 @@ public:
 		return setValue;
 	}
 
-	bool contains(cvar key) const
+	bool contains(const cvar key) const
 	{
 		if (type == valueType::LIST)
 			//return (listValue && key.getInt32() < listValue->size()) ? true : false;
@@ -504,7 +501,7 @@ private:
 	// remove all occurrences of right from left if any
 	static std::string subStrings(std::string left, const std::string& right)
 	{
-		auto len = right.length();
+		const auto len = right.length();
 		size_t idx;
 		while ((idx = left.find(right)) != -1)
 			left.erase(idx, len);
@@ -551,7 +548,7 @@ public:
 	{
 		if (this->type == valueType::LIST && listValue)
 		{
-			auto index = std::stoi(idx);
+			const auto index = std::stoi(idx);
 
 			if (index < 0)
 				throw std::runtime_error("negative index in List");
@@ -573,7 +570,7 @@ public:
 	{
 		if (this->type == valueType::LIST && listValue)
 		{
-			auto index = std::stoi(idx);
+			const auto index = std::stoi(idx);
 
 			if (index < 0)
 				throw std::runtime_error("negative index in List");
@@ -1703,27 +1700,27 @@ public:
 		case valueType::INT64:
 			if (right.type == valueType::DBL || right.type == valueType::FLT)
 			{
-				auto tmp = right.getDouble();
+				const auto tmp = right.getDouble();
 				if (tmp == 0)
 					throw std::runtime_error("divide by zero");
 				return cvar{ this->getDouble() / tmp };
 			}
 			{
-				auto tmp = right.getInt64();
+				const auto tmp = right.getInt64();
 				if (tmp == 0)
 					throw std::runtime_error("divide by zero");
 				return cvar{ *this / tmp };
 			}
 		case valueType::FLT:
 			{
-				auto tmp = right.getFloat();
+				const auto tmp = right.getFloat();
 				if (tmp == 0)
 					throw std::runtime_error("divide by zero");
 				return cvar{ *this / tmp };
 			}
 		case valueType::DBL:
 			{
-				auto tmp = right.getDouble();
+				const auto tmp = right.getDouble();
 				if (tmp == 0)
 					throw std::runtime_error("divide by zero");
 				return cvar{ *this / tmp };
@@ -2103,7 +2100,7 @@ public:
 	// << overload for std::ostream 
 	friend std::ostream& operator<<(std::ostream& os, const cvar& source)
 	{
-		auto result = source.getString();
+		const auto result = source.getString();
 		os << result;
 		return os;
 	}
@@ -2422,7 +2419,7 @@ inline bool operator ==(const cvar& left, const std::string& right)
 
 inline bool operator ==(const cvar& left, const char* right)
 {
-	auto state =
+	const auto state =
 		(strcmp(right, "0") == 0 ||
 			strcmp(right, "false") == 0 ||
 			strlen(right) == 0) ? false : true;
@@ -2431,7 +2428,7 @@ inline bool operator ==(const cvar& left, const char* right)
 
 inline bool operator ==(const char* left, const cvar& right)
 {
-	auto state =
+	const auto state =
 		(strcmp(left, "0") == 0 ||
 			strcmp(left, "false") == 0 ||
 			strlen(left) == 0) ? false : true;
@@ -3050,12 +3047,12 @@ inline cvar operator-(const char* left, const cvar& right)
 	return cvar{ right.subStrings(std::string{left}, right.getString()) };
 }
 
-inline cvar operator""_cvar(unsigned long long val)
+inline cvar operator""_cvar(const unsigned long long val)
 {
 	return cvar{ static_cast<int64_t>(val) };
 }
 
-inline cvar operator""_cvar(long double val)
+inline cvar operator""_cvar(const long double val)
 {
 	return cvar{ static_cast<double>(val) };
 }

--- a/lib/var/var.h
+++ b/lib/var/var.h
@@ -730,6 +730,12 @@ public:
 			dictValue = nullptr;
 		}
 
+		if (setValue)
+		{
+			delete setValue;
+			setValue = nullptr;
+		}
+
 		list();
 
 		*listValue = source;
@@ -748,6 +754,18 @@ public:
 	template<typename T>
 	cvar& operator=(const std::unordered_set<T>& source)
 	{
+		if (dictValue)
+		{
+			delete dictValue;
+			dictValue = nullptr;
+		}
+
+		if (listValue)
+		{
+			delete listValue;
+			listValue = nullptr;
+		}
+
 		set();
 		for (auto &item : source)
 			setValue->insert(item);
@@ -962,6 +980,13 @@ public:
 	{
 		this->valueString = getString();
 		return this->valueString;
+	}
+	
+	std::string* getStringPtr()
+	{
+		if (type != valueType::STR)
+			throw std::runtime_error("getStringPtr can only be called when type is valueType::STR");
+		return &valueString;
 	}
 
 	// overloads... endless overloads
@@ -2193,6 +2218,18 @@ public:
 template <typename K, typename V>
 cvar& cvar::operator=(const std::unordered_map<K, V>& source)
 {
+	if (setValue)
+	{
+		delete setValue;
+		setValue = nullptr;
+	}
+
+	if (listValue)
+	{
+		delete listValue;
+		listValue = nullptr;
+	}
+
 	dict();
 	for (const std::pair<const K,V>& item : source)
 		(*dictValue)[cvar{ item.first }] = cvar{ item.second };

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -3,25 +3,18 @@
 
 using namespace openset::db;
 
-attr_s::attr_s() :
-	changeTail(nullptr),
-	text(nullptr),
-	ints(0),
-	comp(0)
-{}
-
-void attr_s::addChange(int32_t LinearId, bool State)
+void Attr_s::addChange(const int32_t linearId, const bool state)
 {
 	// using placement new here into a POOL buffer
-	auto change =
-		new(PoolMem::getPool().getPtr(sizeof(attr_changes_s)))
-		attr_changes_s(
-			LinearId, (State) ? 1 : 0, changeTail);
+	const auto change =
+		new(PoolMem::getPool().getPtr(sizeof(Attr_changes_s)))
+		Attr_changes_s(
+			linearId, (state) ? 1 : 0, changeTail);
 
 	changeTail = change;
 }
 
-IndexBits* attr_s::getBits()
+IndexBits* Attr_s::getBits()
 {
 	auto bits = new IndexBits();
 	bits->mount(index, ints);
@@ -41,7 +34,7 @@ IndexBits* attr_s::getBits()
 	return bits;
 }
 
-Attributes::Attributes(int partition, AttributeBlob* attributeBlob, Columns* columns) :
+Attributes::Attributes(const int partition, AttributeBlob* attributeBlob, Columns* columns) :
 	blob(attributeBlob),
 	columns(columns),
 	partition(partition)
@@ -51,77 +44,74 @@ Attributes::Attributes(int partition, AttributeBlob* attributeBlob, Columns* col
 Attributes::~Attributes()
 {}
 
-Attributes::ColumnIndex* Attributes::getColumnIndex(int32_t column)
+Attributes::ColumnIndex* Attributes::getColumnIndex(const int32_t column)
 {
-	auto colRingPair = columnIndex.find(column);
+	const auto colRingPair = columnIndex.find(column);
 
 	if (colRingPair != columnIndex.end())
 		return colRingPair->second;
 
-	auto newRing = new ColumnIndex(ringHint_e::lt_compact);
-
+	const auto newRing = new ColumnIndex(ringHint_e::lt_compact);
 	columnIndex[column] = newRing;
 
 	return newRing;
 }
 
-attr_s* Attributes::getMake(int32_t column, int64_t value)
+Attr_s* Attributes::getMake(const int32_t column, const int64_t value)
 {
-
 	auto columnIndex = getColumnIndex(column);
-	AttrPair* attrPair;
-
-	if ((attrPair = columnIndex->get(value)) == nullptr)
+	
+	if (auto attrPair = columnIndex->get(value); attrPair == nullptr)
 	{
-		auto attr = new(PoolMem::getPool().getPtr(sizeof(attr_s)))attr_s();
+		const auto attr = new(PoolMem::getPool().getPtr(sizeof(Attr_s)))Attr_s();
 		attrPair = columnIndex->set(value, attr);
+		return attrPair->second;
 	}
-
-	return attrPair->second;
+	else
+	{
+		return attrPair->second;
+	}
 }
 
-attr_s* Attributes::getMake(int32_t column, string value)
+Attr_s* Attributes::getMake(const int32_t column, const string value)
 {
 	auto columnIndex = getColumnIndex(column);
-	AttrPair* attrPair;
+	const auto valueHash = MakeHash(value);
 
-	auto valueHash = MakeHash(value);
-
-	if ((attrPair = columnIndex->get(valueHash)) == nullptr)
+	if (auto attrPair = columnIndex->get(valueHash); attrPair == nullptr)
 	{
-		auto attr = new(PoolMem::getPool().getPtr(sizeof(attr_s)))attr_s();
-
+		const auto attr = new(PoolMem::getPool().getPtr(sizeof(Attr_s)))Attr_s();
 		attr->text = blob->storeValue(column, value);
 		attrPair = columnIndex->set(valueHash, attr);
+		return attrPair->second;
 	}
-
-	return attrPair->second;
+	else
+	{
+		return attrPair->second;
+	}
 }
 
-attr_s* Attributes::get(int32_t column, int64_t value)
+Attr_s* Attributes::get(const int32_t column, const int64_t value)
 {
-	auto columnIndex = getColumnIndex(column);
-	AttrPair* attrPair;
-
-	if ((attrPair = columnIndex->get(value)) != nullptr)
+	const auto columnIndex = getColumnIndex(column);
+	
+	if (const auto attrPair = columnIndex->get(value); attrPair != nullptr)
 		return attrPair->second;
 
 	return nullptr;
 }
 
-attr_s* Attributes::get(int32_t column, string value)
+Attr_s* Attributes::get(const int32_t column, const string value)
 {
-	auto columnIndex = getColumnIndex(column);
-	AttrPair* attrPair;
-	auto valueHash = MakeHash(value);
+	const auto columnIndex = getColumnIndex(column);
 
-	if ((attrPair = columnIndex->get(valueHash)) != nullptr)
+	if (const auto attrPair = columnIndex->get(MakeHash(value)); attrPair != nullptr)
 		return attrPair->second;
 
 	return nullptr;
 }
 
-void Attributes::setDirty(int32_t linId, int32_t column, int64_t value, attr_s* attrInfo)
+void Attributes::setDirty(const int32_t linId, const int32_t column, const int64_t value, Attr_s* attrInfo)
 {
 	dirty.insert(attr_key_s::makeKey(column, value));
 	attrInfo->addChange(linId, true);
@@ -134,13 +124,12 @@ void Attributes::clearDirty()
 
 	for (auto& d : dirty)
 	{
-
-		auto columnIndex = getColumnIndex(d.column);
+		const auto columnIndex = getColumnIndex(d.column);
 
 		if ((attrPair = columnIndex->get(d.value)) == nullptr)
 			continue;
 
-		auto attr = attrPair->second;
+		const auto attr = attrPair->second;
 
 		bits.mount(attr->index, attr->ints);
 
@@ -152,7 +141,7 @@ void Attributes::clearDirty()
 				bits.bitSet(t->linId);
 			else
 				bits.bitClear(t->linId);
-			auto prev = t->prev;
+			const auto prev = t->prev;
 			PoolMem::getPool().freePtr(t);
 			t = prev;
 		}
@@ -162,11 +151,11 @@ void Attributes::clearDirty()
 		int64_t compBytes = 0; // OUT value via reference
 
 							   // compress the data, get it back in a pool ptr
-		auto compData = bits.store(compBytes);
-		auto destAttr = recast<attr_s*>(PoolMem::getPool().getPtr(sizeof(attr_s) + compBytes));
+		const auto compData = bits.store(compBytes);
+		const auto destAttr = recast<Attr_s*>(PoolMem::getPool().getPtr(sizeof(Attr_s) + compBytes));
 
 		// copy header
-		memcpy(destAttr, attr, sizeof(attr_s));
+		memcpy(destAttr, attr, sizeof(Attr_s));
 		memcpy(destAttr->index, compData, compBytes);
 
 		// return work buffer from bits.store to the pool
@@ -185,25 +174,25 @@ void Attributes::clearDirty()
 	dirty.clear();
 }
 
-void Attributes::swap(int32_t column, int64_t value, IndexBits* newBits)
+void Attributes::swap(const int32_t column, const int64_t value, IndexBits* newBits)
 {
 	AttrPair* attrPair;
 
-	auto columnIndex = getColumnIndex(column);
+	const auto columnIndex = getColumnIndex(column);
 
 	if ((attrPair = columnIndex->get(value)) == nullptr)
 		return;
 
-	auto attr = attrPair->second;
+	const auto attr = attrPair->second;
 
 	int64_t compBytes = 0; // OUT value via reference
 
-						   // compress the data, get it back in a pool ptr
-	auto compData = newBits->store(compBytes);
-	auto destAttr = recast<attr_s*>(PoolMem::getPool().getPtr(sizeof(attr_s) + compBytes));
+	// compress the data, get it back in a pool ptr, size returned in compBytes
+	const auto compData = newBits->store(compBytes);
+	const auto destAttr = recast<Attr_s*>(PoolMem::getPool().getPtr(sizeof(Attr_s) + compBytes));
 
 	// copy header
-	memcpy(destAttr, attr, sizeof(attr_s));
+	memcpy(destAttr, attr, sizeof(Attr_s));
 	memcpy(destAttr->index, compData, compBytes);
 
 	// return work buffer from bits.store to the pool
@@ -224,10 +213,10 @@ AttributeBlob* Attributes::getBlob() const
 	return blob;
 }
 
-Attributes::AttrList Attributes::getColumnValues(int32_t column, listMode_e mode, int64_t value)
+Attributes::AttrList Attributes::getColumnValues(const int32_t column, const listMode_e mode, const int64_t value)
 {
 	Attributes::AttrList result;
-	attr_s* attr;
+	Attr_s* attr;
 
 	switch (mode)
 	{
@@ -239,16 +228,15 @@ Attributes::AttrList Attributes::getColumnValues(int32_t column, listMode_e mode
 		if (attr)
 			result.push_back(attr);
 		return result;
-		break;
 	case listMode_e::PRESENT:
 		attr = get(column, NONE);
 		if (attr)
 			result.push_back(attr);
 		return result;
-		break;
+		default: ;
 	}
 
-	auto columnIndex = getColumnIndex(column);
+	const auto columnIndex = getColumnIndex(column);
 
 	for (auto &kv : *columnIndex)
 	{
@@ -285,7 +273,7 @@ void Attributes::serialize(HeapStack* mem)
 	*recast<serializedBlockType_e*>(mem->newPtr(sizeof(int64_t))) = serializedBlockType_e::attributes;
 
 	// grab 8 more bytes, this will be the length of the attributes data within the block
-	auto sectionLength = recast<int64_t*>(mem->newPtr(sizeof(int64_t)));
+	const auto sectionLength = recast<int64_t*>(mem->newPtr(sizeof(int64_t)));
 	(*sectionLength) = 0;
 
 	for (auto& col : columnIndex)
@@ -293,7 +281,7 @@ void Attributes::serialize(HeapStack* mem)
 		for (auto &item : *col.second)
 		{
 			// add a header to the HeapStack
-			auto blockHeader = recast<serializedAttr_s*>(mem->newPtr(sizeof(serializedAttr_s)));
+			const auto blockHeader = recast<serializedAttr_s*>(mem->newPtr(sizeof(serializedAttr_s)));
 
 			// fill in the header
 			blockHeader->column = col.first;
@@ -305,14 +293,14 @@ void Attributes::serialize(HeapStack* mem)
 			// copy a text/blob value if any
 			if (blockHeader->textSize)
 			{
-				auto textData = recast<char*>(mem->newPtr(blockHeader->textSize));
+				const auto textData = recast<char*>(mem->newPtr(blockHeader->textSize));
 				memcpy(textData, item.second->text, blockHeader->textSize);
 			}
 
 			// copy the compressed data
 			if (blockHeader->compSize)
 			{
-				auto blockData = recast<char*>(mem->newPtr(blockHeader->compSize));
+				const auto blockData = recast<char*>(mem->newPtr(blockHeader->compSize));
 				memcpy(blockData, item.second->index, blockHeader->compSize);
 			}
 
@@ -333,7 +321,7 @@ int64_t Attributes::deserialize(char* mem)
 
 	read += sizeof(int64_t);
 
-	auto blockSize = *recast<int64_t*>(read);
+	const auto blockSize = *recast<int64_t*>(read);
 
 	if (blockSize == 0)
 	{
@@ -344,16 +332,16 @@ int64_t Attributes::deserialize(char* mem)
 	read += sizeof(int64_t);
 
 	// end is the length of the block after the 16 bytes of header
-	auto end = read + blockSize;
+	const auto end = read + blockSize;
 
 	while (read < end)
 	{
 		// pointer to block
-		auto blockHeader = recast<serializedAttr_s*>(read);
-		auto blockLength = sizeof(serializedAttr_s) + blockHeader->textSize + blockHeader->compSize;
+		const auto blockHeader = recast<serializedAttr_s*>(read);
+		const auto blockLength = sizeof(serializedAttr_s) + blockHeader->textSize + blockHeader->compSize;
 
-		auto textPtr = read + sizeof(serializedAttr_s);
-		auto dataPtr = textPtr + blockHeader->textSize;
+		const auto textPtr = read + sizeof(serializedAttr_s);
+		const auto dataPtr = textPtr + blockHeader->textSize;
 
 		// get or make a column index
 		auto columnIndex = getColumnIndex(blockHeader->column);
@@ -366,7 +354,7 @@ int64_t Attributes::deserialize(char* mem)
 			blobPtr = blob->storeValue(blockHeader->column, std::string{ textPtr, static_cast<size_t>(blockHeader->textSize) });
 
 		// create an attr_s object
-		auto attr = recast<attr_s*>(PoolMem::getPool().getPtr(sizeof(attr_s) + blockHeader->compSize));
+		const auto attr = recast<Attr_s*>(PoolMem::getPool().getPtr(sizeof(Attr_s) + blockHeader->compSize));
 		attr->text = blobPtr;
 		attr->ints = blockHeader->ints;
 		attr->comp = blockHeader->compSize;

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -241,7 +241,7 @@ Attributes::AttrList Attributes::getColumnValues(int32_t column, listMode_e mode
 		return result;
 		break;
 	case listMode_e::PRESENT:
-		attr = get(column, NULLCELL);
+		attr = get(column, NONE);
 		if (attr)
 			result.push_back(attr);
 		return result;

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -12,135 +12,131 @@
 
 using namespace std;
 
-namespace openset
+namespace openset::db
 {
-	namespace db
+
+	const int32_t COL_STAMP = 0;
+	const int32_t COL_ACTION = 1; 
+	const int32_t COL_UUID = 2; 
+	// below are fake columns used for indexing
+	const int32_t COL_TRIGGERS = 3; 
+	const int32_t COL_EMIT = 4;
+	const int32_t COL_SEGMENT = 5;
+	const int32_t COL_SESSION = 6;
+
+	const int32_t COL_OMIT_FIRST = COL_UUID; // omit >=
+	const int32_t COL_OMIT_LAST = COL_SESSION; // omit <=
+
+	struct BitData_s;
+	class Columns;
+
+#pragma pack(push,1)
+
+	struct Attr_changes_s
 	{
+		int32_t linId{ 0 }; // linear ID of Person
+		int32_t state{ 0 }; // 1 or 0
+		Attr_changes_s* prev{ nullptr }; // tail linked.
+		Attr_changes_s()
+		{}
 
-		const int32_t COL_STAMP = 0;
-		const int32_t COL_ACTION = 1; // below are fake columns used for indexing
-		const int32_t COL_UUID = 2; // below are fake columns used for indexing
-		const int32_t COL_TRIGGERS = 3; 
-		const int32_t COL_EMIT = 4;
-		const int32_t COL_SEGMENT = 5;
+		Attr_changes_s(const int32_t linId, const int32_t state, Attr_changes_s* prev) :
+			linId(linId), state(state), prev(prev)
+		{}
+	};
 
-		const int32_t COL_OMIT_FIRST = COL_UUID; // omit >=
-		const int32_t COL_OMIT_LAST = COL_SEGMENT; // omit <=
+	union Attr_value_u
+	{
+		int64_t numeric;
+		char* blob; // shared location in attributes blob
+	};
 
-		struct BitData_s;
-		class Columns;
+	/*
+	attr_s defines an index item. It is cast over a variable length
+	chunk of memory. "people" is an array of bytes containing
+	a compressed bit index
+	*/
+	struct Attr_s
+	{
+		Attr_changes_s* changeTail{ nullptr };
+		char* text{ nullptr };
+		int32_t ints{ 0 }; // number of unsigned int64 integers uncompressed data uses
+		int32_t comp{ 0 }; // compressed size in bytes
+		char index[1]; // char* (1st byte) of packed index bits struct
 
-#pragma pack(push,1)
-
-		struct attr_changes_s
-		{
-			int32_t linId; // linear ID of Person
-			int32_t state; // 1 or 0
-			attr_changes_s* prev; // tail linked.
-			attr_changes_s() :
-				linId(0), state(0), prev(nullptr)
-			{}
-
-			attr_changes_s(int32_t linId, int32_t state, attr_changes_s* prev) :
-				linId(linId), state(state), prev(prev)
-			{}
-		};
-
-		union attr_value_u
-		{
-			int64_t numeric;
-			char* blob; // shared location in attributes blob
-		};
-
-		/*
-		attr_s defines an index item. It is cast over a variable length
-		chunk of memory. "people" is an array of bytes containing
-		a compressed bit index
-		*/
-		struct attr_s
-		{
-			attr_changes_s* changeTail;
-			char* text;
-			int32_t ints; // number of unsigned int64 integers uncompressed data uses
-			int32_t comp; // compressed size in bytes
-			char index[1]; // char* (1st byte) of packed index bits struct
-
-			attr_s();
-			void addChange(int32_t LinearId, bool State);
-			IndexBits* getBits();
-		};
-
+		Attr_s() {};
+		void addChange(const int32_t linearId, const bool state);
+		IndexBits* getBits();
+	};
 #pragma pack(pop)
 
-
-		class Attributes
-		{
+	class Attributes
+	{
 #pragma pack(push,1)
-			struct serializedAttr_s
-			{
-				int32_t column;
-				int64_t hashValue;
-				int32_t ints; // number of int64_t's used when decompressed
-				int32_t textSize;
-				int32_t compSize;
-			};
+		struct serializedAttr_s
+		{
+			int32_t column;
+			int64_t hashValue;
+			int32_t ints; // number of int64_t's used when decompressed
+			int32_t textSize;
+			int32_t compSize;
+		};
 #pragma pack(pop)
 
-		public:
+	public:
 
-			enum class listMode_e : int32_t
-			{
-				EQ,
-				NEQ,
-				GT,
-				GTE,
-				LT,
-				LTE,
-				PRESENT
-			};
-
-			using AttrList = vector<attr_s*>;
-
-			// value and attribute info
-			using ColumnIndex = bigRing<int64_t, attr_s*>;
-			using AttrPair = pair<int64_t, attr_s*>;
-
-			unordered_set<attr_key_s> dirty;
-			unordered_map<int32_t, ColumnIndex*> columnIndex;
-
-			AttributeBlob* blob;
-			Columns* columns;
-			int partition;
-
-			explicit Attributes(int parition, AttributeBlob* attributeBlob, Columns* columns);
-			~Attributes();
-
-			ColumnIndex* getColumnIndex(int32_t column);
-
-			attr_s* getMake(int32_t column, int64_t value);
-			attr_s* getMake(int32_t column, string value);
-
-			attr_s* get(int32_t column, int64_t value);
-			attr_s* get(int32_t column, string value);
-
-			void setDirty(int32_t linId, int32_t column, int64_t value, attr_s* attrInfo);
-			void clearDirty();
-
-			// replace an indexes bits with new ones, used when generating segments
-			void swap(int32_t column, int64_t value, IndexBits* newBits);
-
-			AttributeBlob* getBlob() const;
-
-			AttrList getColumnValues(int32_t column, listMode_e mode, int64_t value);
-
-			bool operator==(const Attributes& other) const
-			{
-				return (partition == other.partition);
-			}
-
-			void serialize(HeapStack* mem);
-			int64_t deserialize(char* mem);
+		enum class listMode_e : int32_t
+		{
+			EQ,
+			NEQ,
+			GT,
+			GTE,
+			LT,
+			LTE,
+			PRESENT
 		};
+
+		using AttrList = vector<Attr_s*>;
+
+		// value and attribute info
+		using ColumnIndex = bigRing<int64_t, Attr_s*>;
+		using AttrPair = pair<int64_t, Attr_s*>;
+
+		unordered_set<attr_key_s> dirty;
+		unordered_map<int32_t, ColumnIndex*> columnIndex;
+
+		AttributeBlob* blob;
+		Columns* columns;
+		int partition;
+
+		explicit Attributes(const int parition, AttributeBlob* attributeBlob, Columns* columns);
+		~Attributes();
+
+		ColumnIndex* getColumnIndex(const int32_t column);
+
+		Attr_s* getMake(const int32_t column, const int64_t value);
+		Attr_s* getMake(const int32_t column, const string value);
+
+		Attr_s* get(const int32_t column, const int64_t value);
+		Attr_s* get(const int32_t column, const string value);
+
+		void setDirty(const int32_t linId, const int32_t column, const int64_t value, Attr_s* attrInfo);
+		void clearDirty();
+
+		// replace an indexes bits with new ones, used when generating segments
+		void swap(const int32_t column, const int64_t value, IndexBits* newBits);
+
+		AttributeBlob* getBlob() const;
+
+		AttrList getColumnValues(const int32_t column, const listMode_e mode, const int64_t value);
+
+		bool operator==(const Attributes& other) const
+		{
+			return (partition == other.partition);
+		}
+
+		void serialize(HeapStack* mem);
+		int64_t deserialize(char* mem);
 	};
 };
 

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -422,9 +422,9 @@ void Grid::prepare()
 		{
 			if (sessionColumn != -1)
 			{
-				if (lastSessionTime && row->cols[0] - lastSessionTime > table->sessionTime)
+				if (row->cols[COL_STAMP] - lastSessionTime > sessionTime)
 					++session;
-				lastSessionTime = row->cols[0];
+				lastSessionTime = row->cols[COL_STAMP];
 				row->cols[sessionColumn] = session;
 			}
 			

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -188,7 +188,7 @@ cjson Grid::toJSON(bool condensed) const
 
 					auto value = accumulator[0]->cols[c];
 
-					if (value == NULLCELL)
+					if (value == NONE)
 						continue;
 
 					switch (colInfo->type)
@@ -238,7 +238,7 @@ cjson Grid::toJSON(bool condensed) const
 
 				for (auto r : accumulator)
 					for (auto c = 0; c < columnCount; ++c)
-						if (r->cols[c] != NULLCELL)
+						if (r->cols[c] != NONE)
 						{
 							auto key = make_pair(c, r->cols[c]);
 							if (!counts.count(key))
@@ -264,7 +264,7 @@ cjson Grid::toJSON(bool condensed) const
 
 						auto value = accumulator[0]->cols[c];
 
-						if (value == NULLCELL)
+						if (value == NONE)
 							continue;
 
 						// are these all the same on every row in the group? If not, skip
@@ -318,7 +318,7 @@ cjson Grid::toJSON(bool condensed) const
 
 						auto value = r->cols[c];
 
-						if (value == NULLCELL)
+						if (value == NONE)
 							continue;
 
 						// are these all the same on every row in the group? If not, skip
@@ -369,7 +369,7 @@ col_s* Grid::newRow()
 	volatile auto row = recast<int64_t*>(mem.newPtr(rowBytes));
 
 	for (auto iter = row; iter < row + columnCount; ++iter)
-        *iter = NULLCELL;
+        *iter = NONE;
 
 	if (uuidColumn != -1)
 		*(row + uuidColumn) = rawData->id;
@@ -576,7 +576,7 @@ personData_s* Grid::commit()
 	{
 		for (auto c = 0; c < columnCount; ++c)
 		{
-			if (r->cols[c] == NULLCELL ||
+			if (r->cols[c] == NONE ||
 				(reverseMap[c] >= COL_OMIT_FIRST && reverseMap[c] <= COL_OMIT_LAST))
 				continue;
 			bytesNeeded += sizeOfCast;
@@ -598,7 +598,7 @@ personData_s* Grid::commit()
 		{
 			cursor = recast<cast_s*>(write);
 
-			if (r->cols[c] == NULLCELL ||
+			if (r->cols[c] == NONE ||
 				(columnMap[c] >= COL_OMIT_FIRST && columnMap[c] <= COL_OMIT_LAST))
 				continue;
 
@@ -945,10 +945,10 @@ void Grid::insert(cjson* rowData)
 
 				fillCount++;
 
-				auto attrInfo = attributes->getMake(schemaCol, NULLCELL);
-				attributes->setDirty(this->rawData->linId, schemaCol, NULLCELL, attrInfo);
+				auto attrInfo = attributes->getMake(schemaCol, NONE);
+				attributes->setDirty(this->rawData->linId, schemaCol, NONE, attrInfo);
 				
-				auto val = NULLCELL;
+				auto val = NONE;
 
 				switch (c->type())
 				{
@@ -1059,7 +1059,7 @@ void Grid::insert(cjson* rowData)
 					break;
 
 				default:
-					val = NULLCELL;
+					val = NONE;
 					break;
 				}
 

--- a/src/grid.h
+++ b/src/grid.h
@@ -48,7 +48,7 @@ namespace openset
 			future_trigger = 2, // scheduled trigger
 		};
 
-		struct flags_s // 26 bytes.
+		struct Flags_s // 26 bytes.
 		{
 			int64_t reference; // what this flag refers to (i.e. a trigger ID)
 			int64_t context; // value 1 (i.e. hash of function name)
@@ -56,15 +56,15 @@ namespace openset
 			flagType_e flagType;
 
 			void set(
-				flagType_e FlagType,
-				int64_t Reference,
-				int64_t Context,
-				int64_t Value) 
+				const flagType_e flagType,
+				const int64_t reference,
+				const int64_t context,
+				const int64_t value)
 			{
-				flagType = FlagType;
-				reference = Reference;
-				context = Context;
-				value = Value;
+				this->flagType = flagType;
+				this->reference = reference;
+				this->context = context;
+				this->value = value;
 			};
 
 			// Note: flags are implemented using a Pool block and that pointer
@@ -74,7 +74,7 @@ namespace openset
 			// to cast and check the buffer. 
 		};
 
-		struct personData_s
+		struct PersonData_s
 		{
 			/*
 			*  A User Record is a packed structure with the following layout
@@ -112,7 +112,7 @@ namespace openset
 				idBytes = idString.length();
 			}
 
-			void setIdStr(char* idString, int len)
+			void setIdStr(char* idString, const int len)
 			{
 				std::memcpy(events, idString, len);
 				idBytes = len;
@@ -120,19 +120,19 @@ namespace openset
 
 			int64_t flagBytes() const
 			{
-				return (flagRecords * sizeof(flags_s));
+				return (flagRecords * sizeof(Flags_s));
 			}
 
 			int64_t size() const
 			{
-				return sizeof(personData_s) + comp + propBytes + idBytes + flagBytes();
+				return sizeof(PersonData_s) + comp + propBytes + idBytes + flagBytes();
 			}
 
-			flags_s* getFlags() 
+			Flags_s* getFlags() 
 			{
 				if (!flagRecords)
 					return nullptr;
-				return reinterpret_cast<flags_s*>(events + idBytes);
+				return reinterpret_cast<Flags_s*>(events + idBytes);
 			}
 
 			char* getIdPtr()
@@ -153,31 +153,31 @@ namespace openset
 			}
 		};
 
-		struct col_s
+		struct Col_s
 		{
 			int64_t cols[MAXCOLUMNS];
 		};
 #pragma pack(pop)
 
-		using Rows = vector<col_s*>;
+		using Rows = vector<Col_s*>;
 
 		class Grid
 		{
 		private:
 
-			using lineNodes = vector<cjson*>;
-			using expandedRows = vector<lineNodes>;
+			using LineNodes = vector<cjson*>;
+			using ExpandedRows = vector<LineNodes>;
 
 #pragma pack(push,1)
-			struct cast_s
+			struct Cast_s
 			{
 				int16_t columnNum; 
 				int64_t val64;
 			};
 #pragma pack(pop)			
 
-			const static int sizeOfCastHeader = sizeof(cast_s::columnNum);
-			const static int sizeOfCast = sizeof(cast_s);
+			const static int sizeOfCastHeader = sizeof(Cast_s::columnNum);
+			const static int sizeOfCast = sizeof(Cast_s);
 
 			// mapping
 			int16_t columnMap[MAXCOLUMNS]; // TODO - FIX THIS
@@ -189,10 +189,11 @@ namespace openset
 			// so rows have tight cache affinity 
 			HeapStack mem;
 			Rows rows;
-			personData_s* rawData{ nullptr };
+			PersonData_s* rawData{ nullptr };
 
 			int32_t columnCount{ 0 };
 			int32_t uuidColumn{ -1 }; // auto mapped in prepare
+			int32_t sessionColumn{ -1 };
 
 			Table* table{ nullptr };
 			Attributes* attributes{ nullptr };
@@ -220,21 +221,21 @@ namespace openset
 			bool mapSchema(Table* tablePtr, Attributes* attributesPtr);
 			bool mapSchema(Table* tablePtr, Attributes* attributesPtr, const vector<string>& columnNames);
 
-			void mount(personData_s* personData);
+			void mount(PersonData_s* personData);
 			void prepare();
 			void insert(cjson* rowData);
 
-			personData_s* addFlag(flagType_e flagType, int64_t reference, int64_t context, int64_t value);
-			personData_s* clearFlag(flagType_e flagType, int64_t reference, int64_t context);
+			PersonData_s* addFlag(const flagType_e flagType, const int64_t reference, const int64_t context, const int64_t value);
+			PersonData_s* clearFlag(const flagType_e flagType, const  int64_t reference, const int64_t context);
 
 			/**
 			* \brief re-encodes and compresses the row data after inserts
 			*/
-			personData_s* commit();
+			PersonData_s* commit();
 
 			// given an actual schema column, what is the 
 			// column in the grid (which is compact)
-			inline int getGridColumn( int schemaColumn ) const
+			inline int getGridColumn(const int schemaColumn) const
 			{
 				return reverseMap[schemaColumn];
 			}
@@ -281,13 +282,13 @@ namespace openset
 				return table;
 			}
 
-			cjson toJSON(bool condensed = true) const;
+			cjson toJSON(const bool condensed = true) const;
 
 			// brings object back to zero state
 			void reinit();
 
 		private:
-			col_s* newRow();
+			Col_s* newRow();
 			/**
 			* \brief reset rows (without resetting mappings)
 			*
@@ -295,7 +296,7 @@ namespace openset
 			*       want to do that once if we are re-using grids (or Person)
 			*       objects.
 			*/
-			expandedRows iterate_expand(cjson* json) const;
+			ExpandedRows iterate_expand(cjson* json) const;
 
 			// ready object for re-use while maintaining mountings
 			void reset();

--- a/src/grid.h
+++ b/src/grid.h
@@ -194,6 +194,7 @@ namespace openset
 			int32_t columnCount{ 0 };
 			int32_t uuidColumn{ -1 }; // auto mapped in prepare
 			int32_t sessionColumn{ -1 };
+			int64_t sessionTime{ 60'000LL * 30LL }; // 30 minutes
 
 			Table* table{ nullptr };
 			Attributes* attributes{ nullptr };
@@ -220,6 +221,11 @@ namespace openset
 			*/
 			bool mapSchema(Table* tablePtr, Attributes* attributesPtr);
 			bool mapSchema(Table* tablePtr, Attributes* attributesPtr, const vector<string>& columnNames);
+
+			void setSessionTime(const int64_t sessionTime)
+			{
+				this->sessionTime = sessionTime;
+			}
 
 			void mount(PersonData_s* personData);
 			void prepare();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,7 @@ int main(const int argc, char* argv[])
 		}
 	}
 
-	if (test)
+//	if (test)
 	{
 		const auto testRes = unitTest();
 		exit(testRes ? 0 : 1); // exit with 1 on test fail

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,7 @@ void StartOpenSet(openset::config::CommandlineArgs args)
 
 }
 
-int main(int argc, char* argv[])
+int main(const int argc, char* argv[])
 {
 	openset::config::CommandlineArgs args;
 

--- a/src/oloop_count.cpp
+++ b/src/oloop_count.cpp
@@ -51,7 +51,7 @@ void OpenLoopCount::storeResult(std::string name, int64_t count) const
 
 	const auto set_cb = [count](openset::result::Accumulator* resultColumns)
 	{
-		if (resultColumns->columns[0].value == NULLCELL)
+		if (resultColumns->columns[0].value == NONE)
 			resultColumns->columns[0].value = count;
 		else
 			resultColumns->columns[0].value += count;
@@ -200,7 +200,7 @@ bool OpenLoopCount::nextMacro()
 		if (interpreter)
 			delete interpreter;
 
-		interpreter = new Interpreter(macros, openset::query::interpretMode_e::count);
+		interpreter = new Interpreter(macros, openset::query::InterpretMode_e::count);
 		interpreter->setGetSegmentCB(getSegmentCB);
 		interpreter->setBits(bits, maxLinearId);
 
@@ -216,7 +216,7 @@ bool OpenLoopCount::nextMacro()
 		// meaning we do not have to iterate user records
 		if (macros.isSegmentMath)
 		{
-			interpreter->interpretMode = interpretMode_e::count;
+			interpreter->interpretMode = InterpretMode_e::count;
 
 			interpreter->mount(&person);
 			interpreter->exec();

--- a/src/oloop_count.cpp
+++ b/src/oloop_count.cpp
@@ -282,7 +282,7 @@ void OpenLoopCount::prepare()
 
 void OpenLoopCount::run()
 {
-	openset::db::personData_s* personData;
+	openset::db::PersonData_s* personData;
 	while (true)
 	{
 		if (sliceComplete())

--- a/src/oloop_count.h
+++ b/src/oloop_count.h
@@ -40,7 +40,7 @@ namespace openset
 			std::unordered_set<std::string> segmentWasCached;
 
 			query::QueryPairs::iterator macroIter;
-			query::macro_s macros;
+			query::Macro_S macros;
 
 			openset::query::BitMap resultBits;
 

--- a/src/oloop_count.h
+++ b/src/oloop_count.h
@@ -40,7 +40,7 @@ namespace openset
 			std::unordered_set<std::string> segmentWasCached;
 
 			query::QueryPairs::iterator macroIter;
-			query::Macro_S macros;
+			query::Macro_s macros;
 
 			openset::query::BitMap resultBits;
 

--- a/src/oloop_query.cpp
+++ b/src/oloop_query.cpp
@@ -13,7 +13,7 @@ using namespace openset::result;
 OpenLoopQuery::OpenLoopQuery(
 	ShuttleLambda<CellQueryResult_s>* shuttle,
 	Table* table, 
-	Macro_S macros, 
+	Macro_s macros, 
 	openset::result::ResultSet* result,
 	int instance) :
 
@@ -85,6 +85,7 @@ void OpenLoopQuery::prepare()
 
 	// map table, partition and select schema columns to the Person object
 	person.mapTable(table, loop->partition, mappedColumns);
+	person.setSessionTime(macros.sessionTime);
 	
 	startTime = Now();
 }

--- a/src/oloop_query.cpp
+++ b/src/oloop_query.cpp
@@ -92,7 +92,7 @@ void OpenLoopQuery::prepare()
 void OpenLoopQuery::run()
 {
 	auto count = 0;
-	openset::db::personData_s* personData;
+	openset::db::PersonData_s* personData;
 	while (true)
 	{
 		if (sliceComplete())

--- a/src/oloop_query.cpp
+++ b/src/oloop_query.cpp
@@ -13,7 +13,7 @@ using namespace openset::result;
 OpenLoopQuery::OpenLoopQuery(
 	ShuttleLambda<CellQueryResult_s>* shuttle,
 	Table* table, 
-	macro_s macros, 
+	Macro_S macros, 
 	openset::result::ResultSet* result,
 	int instance) :
 

--- a/src/oloop_query.h
+++ b/src/oloop_query.h
@@ -20,7 +20,7 @@ namespace openset
 		class OpenLoopQuery : public OpenLoop
 		{
 		public:
-			openset::query::Macro_S macros;
+			openset::query::Macro_s macros;
 			ShuttleLambda<openset::result::CellQueryResult_s>* shuttle;
 			openset::db::Table* table;
 			openset::db::TablePartitioned* parts;
@@ -39,7 +39,7 @@ namespace openset
 			explicit OpenLoopQuery(
 				ShuttleLambda<openset::result::CellQueryResult_s>* shuttle,
 				openset::db::Table* table,
-				openset::query::Macro_S macros, 
+				openset::query::Macro_s macros, 
 				openset::result::ResultSet* result,
 				int instance);
 

--- a/src/oloop_query.h
+++ b/src/oloop_query.h
@@ -20,7 +20,7 @@ namespace openset
 		class OpenLoopQuery : public OpenLoop
 		{
 		public:
-			openset::query::macro_s macros;
+			openset::query::Macro_S macros;
 			ShuttleLambda<openset::result::CellQueryResult_s>* shuttle;
 			openset::db::Table* table;
 			openset::db::TablePartitioned* parts;
@@ -39,7 +39,7 @@ namespace openset
 			explicit OpenLoopQuery(
 				ShuttleLambda<openset::result::CellQueryResult_s>* shuttle,
 				openset::db::Table* table,
-				openset::query::macro_s macros, 
+				openset::query::Macro_S macros, 
 				openset::result::ResultSet* result,
 				int instance);
 

--- a/src/oloop_retrigger.cpp
+++ b/src/oloop_retrigger.cpp
@@ -33,7 +33,7 @@ void OpenLoopRetrigger::run()
 	auto maxLinearId = parts->people.peopleCount();
 	
 
-	openset::db::personData_s* personData;
+	openset::db::PersonData_s* personData;
 
 	auto now = Now();
 

--- a/src/oloop_seg_refresh.cpp
+++ b/src/oloop_seg_refresh.cpp
@@ -161,7 +161,7 @@ bool OpenLoopSegmentRefresh::nextExpired()
 			continue;
 		}
 
-		interpreter = new Interpreter(macros, openset::query::interpretMode_e::count);
+		interpreter = new Interpreter(macros, openset::query::InterpretMode_e::count);
 		interpreter->setGetSegmentCB(getSegmentCB);
 		interpreter->setBits(bits, maxLinearId);
 
@@ -177,7 +177,7 @@ bool OpenLoopSegmentRefresh::nextExpired()
 		// meaning we do not have to iterate user records
 		if (macros.isSegmentMath)
 		{
-			interpreter->interpretMode = interpretMode_e::count;
+			interpreter->interpretMode = InterpretMode_e::count;
 
 			interpreter->mount(&person);
 			interpreter->exec();

--- a/src/oloop_seg_refresh.cpp
+++ b/src/oloop_seg_refresh.cpp
@@ -212,7 +212,7 @@ void OpenLoopSegmentRefresh::run()
 	if (!interpreter)
 		return;
 
-	openset::db::personData_s* personData;
+	openset::db::PersonData_s* personData;
 	while (true)
 	{
 		if (sliceComplete())

--- a/src/oloop_seg_refresh.h
+++ b/src/oloop_seg_refresh.h
@@ -34,7 +34,7 @@ namespace openset
 			openset::db::IndexBits* index;
 
 			std::string segmentName;
-			query::Macro_S macros;
+			query::Macro_s macros;
 			std::string resultName;
 
 			explicit OpenLoopSegmentRefresh(TablePartitioned* parts);

--- a/src/oloop_seg_refresh.h
+++ b/src/oloop_seg_refresh.h
@@ -34,7 +34,7 @@ namespace openset
 			openset::db::IndexBits* index;
 
 			std::string segmentName;
-			query::macro_s macros;
+			query::Macro_S macros;
 			std::string resultName;
 
 			explicit OpenLoopSegmentRefresh(TablePartitioned* parts);

--- a/src/people.cpp
+++ b/src/people.cpp
@@ -12,7 +12,7 @@ People::People(int partition) :
 People::~People()
 {}
 
-personData_s* People::getPersonByID(int64_t userId)
+PersonData_s* People::getPersonByID(int64_t userId)
 {
 	int32_t linId;
 
@@ -22,7 +22,7 @@ personData_s* People::getPersonByID(int64_t userId)
 	return nullptr;
 }
 
-personData_s* People::getPersonByID(string userIdString)
+PersonData_s* People::getPersonByID(string userIdString)
 {
 	auto hashId = MakeHash(userIdString);
 
@@ -41,7 +41,7 @@ personData_s* People::getPersonByID(string userIdString)
 	}
 }
 
-personData_s* People::getPersonByLIN(int32_t linId)
+PersonData_s* People::getPersonByLIN(int32_t linId)
 {
 	// check ranges
 	if (linId < 0 || linId >= peopleLinear.size())
@@ -50,7 +50,7 @@ personData_s* People::getPersonByLIN(int32_t linId)
 	return peopleLinear[linId];
 }
 
-personData_s* People::getmakePerson(string userIdString)
+PersonData_s* People::getmakePerson(string userIdString)
 {
 	auto hashId = MakeHash(userIdString);
 	auto idLen = userIdString.length();
@@ -61,7 +61,7 @@ personData_s* People::getmakePerson(string userIdString)
 
 		if (!person) // not found, lets create
 		{
-			auto newUser = recast<personData_s*>(PoolMem::getPool().getPtr(sizeof(personData_s) + idLen));
+			auto newUser = recast<PersonData_s*>(PoolMem::getPool().getPtr(sizeof(PersonData_s) + idLen));
 
 			//newUser->idstr = cast<char*>(PoolMem::getPool().getPtr(idLen + 1));
 			//strcpy(newUser->idstr, idCstr);
@@ -107,7 +107,7 @@ void People::serialize(HeapStack* mem)
 
 	for (auto person : peopleLinear)
 	{
-		auto serializedPerson = recast<personData_s*>(mem->newPtr(person->size()));
+		auto serializedPerson = recast<PersonData_s*>(mem->newPtr(person->size()));
 		memcpy(serializedPerson, person, person->size());
 		*sectionLength += person->size();
 	}
@@ -137,10 +137,10 @@ int64_t People::deserialize(char* mem)
 
 	while (read < end)
 	{
-		auto streamPerson = recast<personData_s*>(read);
+		auto streamPerson = recast<PersonData_s*>(read);
 		auto streamPersonLen = streamPerson->size();
 
-		auto person = recast<personData_s*>(PoolMem::getPool().getPtr(streamPersonLen));
+		auto person = recast<PersonData_s*>(PoolMem::getPool().getPtr(streamPersonLen));
 		memcpy(person, streamPerson, streamPersonLen);
 
 		// grow if a record was excluded during serialization 

--- a/src/people.h
+++ b/src/people.h
@@ -14,27 +14,27 @@ namespace openset
 {
 	namespace db
 	{
-		struct personData_s;
+		struct PersonData_s;
 
 		class People
 		{
 		public:
 			bigRing<int64_t, int32_t> peopleMap; // probably delete this!
-			vector<personData_s*> peopleLinear;
+			vector<PersonData_s*> peopleLinear;
 			int partition;
 		public:
 			explicit People(int partition);
 			~People();
 
-			personData_s* getPersonByID(int64_t userId);
-			personData_s* getPersonByID(string userIdString);
-			personData_s* getPersonByLIN(int32_t linId);
+			PersonData_s* getPersonByID(int64_t userId);
+			PersonData_s* getPersonByID(string userIdString);
+			PersonData_s* getPersonByLIN(int32_t linId);
 
 			// will return a "found" person if one exists
 			// or create a new one
-			personData_s* getmakePerson(string userIdString);
+			PersonData_s* getmakePerson(string userIdString);
 
-			void replacePersonRecord(personData_s* newRecord)
+			void replacePersonRecord(PersonData_s* newRecord)
 			{
 				if (newRecord)
 					peopleLinear[newRecord->linId] = newRecord;

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -77,7 +77,7 @@ bool Person::mapSchemaList(const vector<string>& columnNames)
 	return grid.mapSchema(table, attributes, columnNames);
 }
 
-void Person::mount(personData_s* personData)
+void Person::mount(PersonData_s* personData)
 {
 #if defined(_DEBUG) || defined(NDEBUG)
 	Logger::get().fatal((table), "mapTable must be called before mount");
@@ -96,7 +96,7 @@ void Person::insert(cjson* rowData)
 	grid.insert(rowData);
 }
 
-personData_s* Person::commit()
+PersonData_s* Person::commit()
 {
 	data = grid.commit();
 	people->replacePersonRecord(data);

--- a/src/person.h
+++ b/src/person.h
@@ -47,7 +47,7 @@ namespace openset
 
 		private:
 			Grid grid;
-			personData_s* data;
+			PersonData_s* data;
 			Table* table;
 			Attributes* attributes;
 			AttributeBlob* blob;
@@ -74,7 +74,7 @@ namespace openset
 			 * \brief maps a personData_s object to the Person object
 			 * \param[in] personData 
 			 */
-			void mount(personData_s* personData);
+			void mount(PersonData_s* personData);
 
 			/**
 			 * \brief expands personData_s object into Grid object
@@ -95,7 +95,7 @@ namespace openset
 				return data->id;
 			}
 
-			inline personData_s* getMeta() const
+			inline PersonData_s* getMeta() const
 			{
 				return data;
 			}
@@ -116,7 +116,7 @@ namespace openset
 			 *       from the caller will be invalid, so this commit
 			 *       returns the new pointer if this is important.
 			 */
-			personData_s* commit();
+			PersonData_s* commit();
 
 		private:
 			/**

--- a/src/person.h
+++ b/src/person.h
@@ -81,6 +81,11 @@ namespace openset
 			 */
 			void prepare();
 
+			void setSessionTime(const int64_t sessionTime)
+			{
+				grid.setSessionTime(sessionTime);
+			}
+
 			/**
 			 * \brief return reference to grid object
 			 * \return Grid const pointer (read only)

--- a/src/querycommon.h
+++ b/src/querycommon.h
@@ -14,7 +14,7 @@ namespace openset
 {
 	namespace query
 	{
-		enum class blockType_e
+		enum class BlockType_e
 		{
 			code,
 			lambda,
@@ -22,13 +22,14 @@ namespace openset
 		};
 
 		// Result Column Modifiers						
-		enum class modifiers_e : int32_t
+		enum class Modifiers_e : int32_t
 		{
 			sum,
 			min,
 			max,
 			avg,
 			count,
+			dist_count_person,
 			value,
 			var,
 			second_number,
@@ -50,7 +51,7 @@ namespace openset
 			year_date,
 		};
 
-		enum class opCode_e : int32_t
+		enum class OpCode_e : int32_t
 		{
 			NOP = 0, // No operation
 
@@ -116,7 +117,7 @@ namespace openset
 		};
 
 		// Marshal Functions
-		enum class marshals_e : int64_t
+		enum class Marshals_e : int64_t
 		{
 			marshal_tally,
 			marshal_now,
@@ -164,7 +165,6 @@ namespace openset
 			marshal_union,
 			marshal_compliment,
 			marshal_difference,
-			marshal_session,
 			marshal_session_count,
 			marshal_return,
 			marshal_break,
@@ -206,7 +206,7 @@ namespace openset
 		};
 
 		// enum used for query index optimizer
-		enum class hintOp_e : int64_t
+		enum class HintOp_e : int64_t
 		{
 			UNSUPPORTED,
 			PUSH_EQ,
@@ -234,36 +234,36 @@ namespace std
 	 */
 
 	template <>
-	struct hash<openset::query::modifiers_e>
+	struct hash<openset::query::Modifiers_e>
 	{
-		size_t operator()(const openset::query::modifiers_e& v) const
+		size_t operator()(const openset::query::Modifiers_e& v) const
 		{
 			return static_cast<size_t>(v);
 		}
 	};
 
 	template <>
-	struct hash<openset::query::opCode_e>
+	struct hash<openset::query::OpCode_e>
 	{
-		size_t operator()(const openset::query::opCode_e& v) const
+		size_t operator()(const openset::query::OpCode_e& v) const
 		{
 			return static_cast<size_t>(v);
 		}
 	};
 
 	template <>
-	struct hash<openset::query::hintOp_e>
+	struct hash<openset::query::HintOp_e>
 	{
-		size_t operator()(const openset::query::hintOp_e& v) const
+		size_t operator()(const openset::query::HintOp_e& v) const
 		{
 			return static_cast<size_t>(v);
 		}
 	};
 
 	template <>
-	struct hash<openset::query::marshals_e>
+	struct hash<openset::query::Marshals_e>
 	{
-		size_t operator()(const openset::query::marshals_e& v) const
+		size_t operator()(const openset::query::Marshals_e& v) const
 		{
 			return static_cast<size_t>(v);
 		}
@@ -275,7 +275,7 @@ namespace openset
 	namespace query
 	{
 		// String to Result Columns Modifier
-		static const unordered_map<string, int64_t> timeConstants = {
+		static const unordered_map<string, int64_t> TimeConstants = {
 					{"seconds", 1'000},
 					{"second", 1'000},
 					{"minute", 60'000},
@@ -286,7 +286,7 @@ namespace openset
 					{"days", 86'400'000}
 			};
 
-		static const unordered_map<string, int64_t> withinConstants = {
+		static const unordered_map<string, int64_t> WithinConstants = {
 					{"live", MakeHash("live")},
 					{"first_event", MakeHash("first_event")},
 					{"last_event", MakeHash("last_event")},
@@ -295,28 +295,7 @@ namespace openset
 					{"first_match", MakeHash("first_match")},
 			};
 
-/*
-		enum class within_e : int
-		{
-			live,
-			first_event,
-			last_event,
-			prev_match,
-			first_match
-		};
-
-		static const unordered_map<string, within_e> withinSwitchMap =
-			{
-					{"live", within_e::live},
-					{"first_event", within_e::first_event},
-					{"last_event", within_e::last_event},
-					{"prev_match", within_e::prev_match},
-					{"previous_match", within_e::prev_match},
-					{"first_match", within_e::first_match},
-			};
-*/
-
-		enum class timeSwitch_e : int
+		enum class TimeSwitch_e : int
 		{
 			seconds,
 			minutes,
@@ -324,146 +303,148 @@ namespace openset
 			days
 		};
 
-		static const unordered_map<string, timeSwitch_e> timeSwitchMap =
+		static const unordered_map<string, TimeSwitch_e> TimeSwitchMap =
 			{
-					{"seconds", timeSwitch_e::seconds},
-					{"minutes", timeSwitch_e::minutes},
-					{"hours", timeSwitch_e::hours},
-					{"days", timeSwitch_e::days}
+					{"seconds", TimeSwitch_e::seconds},
+					{"minutes", TimeSwitch_e::minutes},
+					{"hours", TimeSwitch_e::hours},
+					{"days", TimeSwitch_e::days}
 			};
 
 		// String to Result Columns Modifier
-		static const unordered_map<string, modifiers_e> columnModifiers = {
-					{"sum", modifiers_e::sum},
-					{"min", modifiers_e::min},
-					{"max", modifiers_e::max},
-					{"avg", modifiers_e::avg},
-					{"count", modifiers_e::count},
-					{"value", modifiers_e::value},
-					{"val", modifiers_e::value },
-					{"variable", modifiers_e::var },
-					{"var", modifiers_e::var},					
+		static const unordered_map<string, Modifiers_e> ColumnModifiers = {
+					{"sum", Modifiers_e::sum},
+					{"min", Modifiers_e::min},
+					{"max", Modifiers_e::max},
+					{"avg", Modifiers_e::avg},
+					{"count", Modifiers_e::count},
+					{"dist_count_person", Modifiers_e::dist_count_person },
+					{"value", Modifiers_e::value},
+					{"val", Modifiers_e::value },
+					{"variable", Modifiers_e::var },
+					{"var", Modifiers_e::var},					
 			};
 
 		// Modifier to String (for debug output)
-		static const unordered_map<modifiers_e, string> modifierDebugStrings = {
-					{modifiers_e::sum, "SUM"},
-					{modifiers_e::min, "MIN"},
-					{modifiers_e::max, "MAX"},
-					{modifiers_e::avg, "AVG"},
-					{modifiers_e::count, "COUNT"},
-					{modifiers_e::value, "VALUE"},
-					{modifiers_e::var, "VAR"},
-					{modifiers_e::second_number, "SECOND"},
-					{modifiers_e::second_date, "DT_SECOND"},
-					{modifiers_e::minute_number, "MINUTE"},
-					{modifiers_e::minute_date, "DT_MINUTE"},
-					{modifiers_e::hour_number, "HOUR"},
-					{modifiers_e::hour_date, "DT_HOUR"},
-					{modifiers_e::day_date, "DT_DAY"},
-					{modifiers_e::day_of_week, "DAY_OF_WEEK"},
-					{modifiers_e::day_of_month, "DAY_OF_MONTH"},
-					{modifiers_e::day_of_year, "DAY_OF_YEAR"},
-					{modifiers_e::week_date, "DT_WEEK"},
-					{modifiers_e::month_date, "DT_MONTH"},
-					{modifiers_e::month_number, "MONTH"},
-					{modifiers_e::quarter_number, "QUARTER"},
-					{modifiers_e::quarter_date, "DT_QUARTER"},
-					{modifiers_e::year_number, "YEAR"},
-					{modifiers_e::year_date, "DT_YEAR"},
+		static const unordered_map<Modifiers_e, string> ModifierDebugStrings = {
+					{Modifiers_e::sum, "SUM"},
+					{Modifiers_e::min, "MIN"},
+					{Modifiers_e::max, "MAX"},
+					{Modifiers_e::avg, "AVG"},
+					{Modifiers_e::count, "COUNT"},
+					{Modifiers_e::dist_count_person, "DCNTPP" },
+					{Modifiers_e::value, "VALUE"},
+					{Modifiers_e::var, "VAR"},
+					{Modifiers_e::second_number, "SECOND"},
+					{Modifiers_e::second_date, "DT_SECOND"},
+					{Modifiers_e::minute_number, "MINUTE"},
+					{Modifiers_e::minute_date, "DT_MINUTE"},
+					{Modifiers_e::hour_number, "HOUR"},
+					{Modifiers_e::hour_date, "DT_HOUR"},
+					{Modifiers_e::day_date, "DT_DAY"},
+					{Modifiers_e::day_of_week, "DAY_OF_WEEK"},
+					{Modifiers_e::day_of_month, "DAY_OF_MONTH"},
+					{Modifiers_e::day_of_year, "DAY_OF_YEAR"},
+					{Modifiers_e::week_date, "DT_WEEK"},
+					{Modifiers_e::month_date, "DT_MONTH"},
+					{Modifiers_e::month_number, "MONTH"},
+					{Modifiers_e::quarter_number, "QUARTER"},
+					{Modifiers_e::quarter_date, "DT_QUARTER"},
+					{Modifiers_e::year_number, "YEAR"},
+					{Modifiers_e::year_date, "DT_YEAR"},
 			};
 
 		// opCode to String (for debug output)
-		static const unordered_map<opCode_e, string> opDebugStrings =
+		static const unordered_map<OpCode_e, string> OpDebugStrings =
 			{
-					{opCode_e::NOP, "NOP"},
+					{OpCode_e::NOP, "NOP"},
 
-					{opCode_e::PSHTBLCOL, "PSHTBLCOL"},
-					{opCode_e::PSHRESCOL, "PSHRESCOL"},
-					{opCode_e::VARIDX, "VARIDX"},
-					{opCode_e::PSHPAIR, "PSHPAIR"},
+					{OpCode_e::PSHTBLCOL, "PSHTBLCOL"},
+					{OpCode_e::PSHRESCOL, "PSHRESCOL"},
+					{OpCode_e::VARIDX, "VARIDX"},
+					{OpCode_e::PSHPAIR, "PSHPAIR"},
 				//{opCode_e::PSHRESGRP, "PSHRESGRP"},
-					{opCode_e::PSHUSROBJ, "PSHUSROBJ"},
-					{opCode_e::PSHUSROREF, "PSHUSROREF" },
-					{opCode_e::PSHUSRVAR, "PSHUSRVAR"},
-					{ opCode_e::PSHUSRVREF, "PSHUSRVREF" },
-					{opCode_e::PSHLITSTR, "PSHLITSTR"},
-					{opCode_e::PSHLITINT, "PSHLITINT"},
-					{opCode_e::PSHLITFLT, "PSHLITFLT"},
-					{opCode_e::PSHLITNUL, "PSHLITNUL"},
-					{ opCode_e::PSHLITTRUE, "PSHLITTRUE" },
-					{ opCode_e::PSHLITFALSE, "PSHLITFALSE" },
+					{OpCode_e::PSHUSROBJ, "PSHUSROBJ"},
+					{OpCode_e::PSHUSROREF, "PSHUSROREF" },
+					{OpCode_e::PSHUSRVAR, "PSHUSRVAR"},
+					{ OpCode_e::PSHUSRVREF, "PSHUSRVREF" },
+					{OpCode_e::PSHLITSTR, "PSHLITSTR"},
+					{OpCode_e::PSHLITINT, "PSHLITINT"},
+					{OpCode_e::PSHLITFLT, "PSHLITFLT"},
+					{OpCode_e::PSHLITNUL, "PSHLITNUL"},
+					{ OpCode_e::PSHLITTRUE, "PSHLITTRUE" },
+					{ OpCode_e::PSHLITFALSE, "PSHLITFALSE" },
 
-					{opCode_e::POPUSROBJ, "POPUSROBJ"},
-					{opCode_e::POPUSRVAR, "POPUSRVAR"},
-					{opCode_e::POPTBLCOL, "POPTBLCOL"},
-					{opCode_e::POPRESGRP, "POPRESGRP"},
-					{opCode_e::POPRESCOL, "POPRESCOL"},
+					{OpCode_e::POPUSROBJ, "POPUSROBJ"},
+					{OpCode_e::POPUSRVAR, "POPUSRVAR"},
+					{OpCode_e::POPTBLCOL, "POPTBLCOL"},
+					{OpCode_e::POPRESGRP, "POPRESGRP"},
+					{OpCode_e::POPRESCOL, "POPRESCOL"},
 
-					{opCode_e::CNDIF, "CNDIF"},
-					{opCode_e::CNDELIF, "CNDELIF"},
-					{opCode_e::CNDELSE, "CNDELSE"},
+					{OpCode_e::CNDIF, "CNDIF"},
+					{OpCode_e::CNDELIF, "CNDELIF"},
+					{OpCode_e::CNDELSE, "CNDELSE"},
 
-					{opCode_e::ITNEXT, "ITNEXT"},
-					{opCode_e::ITPREV, "ITPREV"},
-					{opCode_e::ITFOR, "ITFOR"},
+					{OpCode_e::ITNEXT, "ITNEXT"},
+					{OpCode_e::ITPREV, "ITPREV"},
+					{OpCode_e::ITFOR, "ITFOR"},
 
-					{opCode_e::MATHADD, "MATHADD"},
-					{opCode_e::MATHSUB, "MATHSUB"},
-					{opCode_e::MATHMUL, "MATHMUL"},
-					{opCode_e::MATHDIV, "MATHDIV"},
+					{OpCode_e::MATHADD, "MATHADD"},
+					{OpCode_e::MATHSUB, "MATHSUB"},
+					{OpCode_e::MATHMUL, "MATHMUL"},
+					{OpCode_e::MATHDIV, "MATHDIV"},
 
-					{ opCode_e::MATHADDEQ, "OPADDEQ"},
-					{ opCode_e::MATHSUBEQ, "OPSUBEQ"},
-					{ opCode_e::MATHMULEQ, "OPMULEQ"},
-					{ opCode_e::MATHDIVEQ, "OPDIVEQ"},
+					{ OpCode_e::MATHADDEQ, "OPADDEQ"},
+					{ OpCode_e::MATHSUBEQ, "OPSUBEQ"},
+					{ OpCode_e::MATHMULEQ, "OPMULEQ"},
+					{ OpCode_e::MATHDIVEQ, "OPDIVEQ"},
 
-					{opCode_e::OPGT, "OPGT"},
-					{opCode_e::OPLT, "OPLT"},
-					{opCode_e::OPGTE, "OPGTE"},
-					{opCode_e::OPLTE, "OPLTE"},
-					{opCode_e::OPEQ, "OPEQ"},
-					{opCode_e::OPNEQ, "OPNEQ"},
-					{opCode_e::OPWTHN, "OPWTHN"},
-					{opCode_e::OPNOT, "OPNOT"},
+					{OpCode_e::OPGT, "OPGT"},
+					{OpCode_e::OPLT, "OPLT"},
+					{OpCode_e::OPGTE, "OPGTE"},
+					{OpCode_e::OPLTE, "OPLTE"},
+					{OpCode_e::OPEQ, "OPEQ"},
+					{OpCode_e::OPNEQ, "OPNEQ"},
+					{OpCode_e::OPWTHN, "OPWTHN"},
+					{OpCode_e::OPNOT, "OPNOT"},
 
-					{opCode_e::LGCAND, "LGCAND"},
-					{opCode_e::LGCOR, "LGCOR"},
+					{OpCode_e::LGCAND, "LGCAND"},
+					{OpCode_e::LGCOR, "LGCOR"},
 
-					{opCode_e::MARSHAL, "MARSHAL"},
-					{opCode_e::CALL, "CALL"},
-					{opCode_e::RETURN, "RETURN"},
+					{OpCode_e::MARSHAL, "MARSHAL"},
+					{OpCode_e::CALL, "CALL"},
+					{OpCode_e::RETURN, "RETURN"},
 
-					{opCode_e::TERM, "TERM"}
+					{OpCode_e::TERM, "TERM"}
 
 			};
 
-		static const unordered_map<string, modifiers_e> timeModifiers =
+		static const unordered_map<string, Modifiers_e> TimeModifiers =
 			{
-					{"second", modifiers_e::second_number},
-					{"date_second", modifiers_e::second_number},
-					{"minute", modifiers_e::minute_number},
-					{"date_minute", modifiers_e::minute_date},
-					{"hour", modifiers_e::hour_number},
-					{"date_hour", modifiers_e::hour_date},
-					{"date_day", modifiers_e::day_date},
-					{"day_of_week", modifiers_e::day_of_week},
-					{"day_of_month", modifiers_e::day_of_month},
-					{"day_of_year", modifiers_e::day_of_year},
-					{"date_week", modifiers_e::week_date},
-					{"date_month", modifiers_e::month_date},
-					{"month", modifiers_e::month_number},
-					{"quarter", modifiers_e::quarter_number},
-					{"date_quarter", modifiers_e::quarter_date},
-					{"year", modifiers_e::year_number},
-					{"date_year", modifiers_e::year_date},
+					{"second", Modifiers_e::second_number},
+					{"date_second", Modifiers_e::second_number},
+					{"minute", Modifiers_e::minute_number},
+					{"date_minute", Modifiers_e::minute_date},
+					{"hour", Modifiers_e::hour_number},
+					{"date_hour", Modifiers_e::hour_date},
+					{"date_day", Modifiers_e::day_date},
+					{"day_of_week", Modifiers_e::day_of_week},
+					{"day_of_month", Modifiers_e::day_of_month},
+					{"day_of_year", Modifiers_e::day_of_year},
+					{"date_week", Modifiers_e::week_date},
+					{"date_month", Modifiers_e::month_date},
+					{"month", Modifiers_e::month_number},
+					{"quarter", Modifiers_e::quarter_number},
+					{"date_quarter", Modifiers_e::quarter_date},
+					{"year", Modifiers_e::year_number},
+					{"date_year", Modifiers_e::year_date},
 			};
 
-		static const unordered_set<modifiers_e> isTimeModifiers =
+		static const unordered_set<Modifiers_e> isTimeModifiers =
 			{
 			};
 
-		static const unordered_set<string> redundantSugar =
+		static const unordered_set<string> RedundantSugar =
 			{
 					{"of"},
 					{"events"},
@@ -471,112 +452,110 @@ namespace openset
 			};
 
 		// Marshal maps
-		static const unordered_map<string, marshals_e> marshals =
+		static const unordered_map<string, Marshals_e> Marshals =
 			{
-					{"tally", marshals_e::marshal_tally},
-					{"now", marshals_e::marshal_now},
-					{"event_time", marshals_e::marshal_event_time},
-					{"last_event", marshals_e::marshal_last_event},
-					{"first_event", marshals_e::marshal_first_event},
-					{"prev_match", marshals_e::marshal_prev_match},
-					{"first_match", marshals_e::marshal_first_match},
-					{"bucket", marshals_e::marshal_bucket},
-					{"round", marshals_e::marshal_round},
-					{"trunc", marshals_e::marshal_trunc},
-					{"fix", marshals_e::marshal_fix},
-					{"to_seconds", marshals_e::marshal_to_seconds},
-					{"to_minutes", marshals_e::marshal_to_minutes},
-					{"to_hours", marshals_e::marshal_to_hours},
-					{"to_days", marshals_e::marshal_to_days},
-					{"get_second", marshals_e::marshal_get_second},
-					{"date_second", marshals_e::marshal_round_second},
-					{"get_minute", marshals_e::marshal_get_minute},
-					{"date_minute", marshals_e::marshal_round_minute},
-					{"get_hour", marshals_e::marshal_get_hour},
-					{"date_hour", marshals_e::marshal_round_hour},
-					{"date_day", marshals_e::marshal_round_day},
-					{"get_day_of_week", marshals_e::marshal_get_day_of_week},
-					{"get_day_of_month", marshals_e::marshal_get_day_of_month},
-					{"get_day_of_year", marshals_e::marshal_get_day_of_year},
-					{"date_week", marshals_e::marshal_round_week},
-					{"date_month", marshals_e::marshal_round_month},
-					{"get_month", marshals_e::marshal_get_month},
-					{"get_quarter", marshals_e::marshal_get_quarter},
-					{"date_quarter", marshals_e::marshal_round_quarter},
-					{"get_year", marshals_e::marshal_get_year},
-					{"date_year", marshals_e::marshal_round_year},
-					{"emit", marshals_e::marshal_emit},
-					{"schedule", marshals_e::marshal_schedule},
-					{"iter_get", marshals_e::marshal_iter_get },
-					{"iter_set", marshals_e::marshal_iter_set },
-					{"iter_move_first", marshals_e::marshal_iter_move_first },
-					{"iter_move_last", marshals_e::marshal_iter_move_last },
-					{"iter_next", marshals_e::marshal_iter_next },
-					{"iter_prev", marshals_e::marshal_iter_prev },
-					{"event_count", marshals_e::marshal_event_count },
-					{"iter_within", marshals_e::marshal_iter_within},
-					{"iter_between", marshals_e::marshal_iter_between},
-					{"population", marshals_e::marshal_population },
-					{"intersection", marshals_e::marshal_intersection},
-					{"union", marshals_e::marshal_union},
-					{"compliment", marshals_e::marshal_compliment},
-					{"difference", marshals_e::marshal_difference},
-					{"marshal_session", marshals_e::marshal_session},
-					{"marshal_session_count", marshals_e::marshal_session_count},
-					{"return", marshals_e::marshal_return},
-					{"continue", marshals_e::marshal_continue},
-					{"break", marshals_e::marshal_break},
-					{"log", marshals_e::marshal_log},
-					{"debug", marshals_e::marshal_debug},
-					{"exit", marshals_e::marshal_exit},
-					{"__internal_init_dict", marshals_e::marshal_init_dict},
-					{"__internal_init_list", marshals_e::marshal_init_list},
-					{ "set", marshals_e::marshal_set },
-					{ "list", marshals_e::marshal_list },
-					{ "dict", marshals_e::marshal_dict },
-					{ "int", marshals_e::marshal_int },
-					{ "float", marshals_e::marshal_float },
-					{ "str", marshals_e::marshal_str },
-					{"__internal_make_dict", marshals_e::marshal_make_dict},
-					{"__internal_make_list", marshals_e::marshal_make_list},
-					{ "len", marshals_e::marshal_len },
-					{ "__append", marshals_e::marshal_append },
-					{ "__update", marshals_e::marshal_update },
-					{ "__add", marshals_e::marshal_add },
-					{ "__remove", marshals_e::marshal_remove },
-					{ "__del", marshals_e::marshal_del },
-					{ "__contains", marshals_e::marshal_contains },
-					{ "__notcontains", marshals_e::marshal_not_contains },
-					{ "__pop", marshals_e::marshal_pop },
-					{ "__clear", marshals_e::marshal_clear },
-					{ "__keys", marshals_e::marshal_keys },
-					{ "__split", marshals_e::marshal_str_split },
-					{ "__find", marshals_e::marshal_str_find },
-					{ "__rfind", marshals_e::marshal_str_rfind },
-					{ "__slice", marshals_e::marshal_str_slice },
-					{ "__strip", marshals_e::marshal_str_strip},
-					{ "range", marshals_e::marshal_range },
-					{ "url_decode", marshals_e::marshal_url_decode }
+					{"tally", Marshals_e::marshal_tally},
+					{"now", Marshals_e::marshal_now},
+					{"event_time", Marshals_e::marshal_event_time},
+					{"last_event", Marshals_e::marshal_last_event},
+					{"first_event", Marshals_e::marshal_first_event},
+					{"prev_match", Marshals_e::marshal_prev_match},
+					{"first_match", Marshals_e::marshal_first_match},
+					{"bucket", Marshals_e::marshal_bucket},
+					{"round", Marshals_e::marshal_round},
+					{"trunc", Marshals_e::marshal_trunc},
+					{"fix", Marshals_e::marshal_fix},
+					{"to_seconds", Marshals_e::marshal_to_seconds},
+					{"to_minutes", Marshals_e::marshal_to_minutes},
+					{"to_hours", Marshals_e::marshal_to_hours},
+					{"to_days", Marshals_e::marshal_to_days},
+					{"get_second", Marshals_e::marshal_get_second},
+					{"date_second", Marshals_e::marshal_round_second},
+					{"get_minute", Marshals_e::marshal_get_minute},
+					{"date_minute", Marshals_e::marshal_round_minute},
+					{"get_hour", Marshals_e::marshal_get_hour},
+					{"date_hour", Marshals_e::marshal_round_hour},
+					{"date_day", Marshals_e::marshal_round_day},
+					{"get_day_of_week", Marshals_e::marshal_get_day_of_week},
+					{"get_day_of_month", Marshals_e::marshal_get_day_of_month},
+					{"get_day_of_year", Marshals_e::marshal_get_day_of_year},
+					{"date_week", Marshals_e::marshal_round_week},
+					{"date_month", Marshals_e::marshal_round_month},
+					{"get_month", Marshals_e::marshal_get_month},
+					{"get_quarter", Marshals_e::marshal_get_quarter},
+					{"date_quarter", Marshals_e::marshal_round_quarter},
+					{"get_year", Marshals_e::marshal_get_year},
+					{"date_year", Marshals_e::marshal_round_year},
+					{"emit", Marshals_e::marshal_emit},
+					{"schedule", Marshals_e::marshal_schedule},
+					{"iter_get", Marshals_e::marshal_iter_get },
+					{"iter_set", Marshals_e::marshal_iter_set },
+					{"iter_move_first", Marshals_e::marshal_iter_move_first },
+					{"iter_move_last", Marshals_e::marshal_iter_move_last },
+					{"iter_next", Marshals_e::marshal_iter_next },
+					{"iter_prev", Marshals_e::marshal_iter_prev },
+					{"event_count", Marshals_e::marshal_event_count },
+					{"iter_within", Marshals_e::marshal_iter_within},
+					{"iter_between", Marshals_e::marshal_iter_between},
+					{"population", Marshals_e::marshal_population },
+					{"intersection", Marshals_e::marshal_intersection},
+					{"union", Marshals_e::marshal_union},
+					{"compliment", Marshals_e::marshal_compliment},
+					{"difference", Marshals_e::marshal_difference},
+					{"session_count", Marshals_e::marshal_session_count},
+					{"return", Marshals_e::marshal_return},
+					{"continue", Marshals_e::marshal_continue},
+					{"break", Marshals_e::marshal_break},
+					{"log", Marshals_e::marshal_log},
+					{"debug", Marshals_e::marshal_debug},
+					{"exit", Marshals_e::marshal_exit},
+					{"__internal_init_dict", Marshals_e::marshal_init_dict},
+					{"__internal_init_list", Marshals_e::marshal_init_list},
+					{ "set", Marshals_e::marshal_set },
+					{ "list", Marshals_e::marshal_list },
+					{ "dict", Marshals_e::marshal_dict },
+					{ "int", Marshals_e::marshal_int },
+					{ "float", Marshals_e::marshal_float },
+					{ "str", Marshals_e::marshal_str },
+					{"__internal_make_dict", Marshals_e::marshal_make_dict},
+					{"__internal_make_list", Marshals_e::marshal_make_list},
+					{ "len", Marshals_e::marshal_len },
+					{ "__append", Marshals_e::marshal_append },
+					{ "__update", Marshals_e::marshal_update },
+					{ "__add", Marshals_e::marshal_add },
+					{ "__remove", Marshals_e::marshal_remove },
+					{ "__del", Marshals_e::marshal_del },
+					{ "__contains", Marshals_e::marshal_contains },
+					{ "__notcontains", Marshals_e::marshal_not_contains },
+					{ "__pop", Marshals_e::marshal_pop },
+					{ "__clear", Marshals_e::marshal_clear },
+					{ "__keys", Marshals_e::marshal_keys },
+					{ "__split", Marshals_e::marshal_str_split },
+					{ "__find", Marshals_e::marshal_str_find },
+					{ "__rfind", Marshals_e::marshal_str_rfind },
+					{ "__slice", Marshals_e::marshal_str_slice },
+					{ "__strip", Marshals_e::marshal_str_strip},
+					{ "range", Marshals_e::marshal_range },
+					{ "url_decode", Marshals_e::marshal_url_decode }
 			};
 
-		static const unordered_set<marshals_e> segmentMathMarshals =
+		static const unordered_set<Marshals_e> SegmentMathMarshals =
 			{
-					{marshals_e::marshal_population },
-					{marshals_e::marshal_intersection},
-					{marshals_e::marshal_union},
-					{marshals_e::marshal_compliment},
-					{marshals_e::marshal_difference},
+					{Marshals_e::marshal_population },
+					{Marshals_e::marshal_intersection},
+					{Marshals_e::marshal_union},
+					{Marshals_e::marshal_compliment},
+					{Marshals_e::marshal_difference},
 			};
 
-		static const unordered_set<marshals_e> sessionMarshals =
+		static const unordered_set<string> SessionMarshals =
 			{
-					{marshals_e::marshal_session},
-					{marshals_e::marshal_session_count},
+					"session_count",
 			};
 
 		// these are marshals that do not take params by default, so they appear
 		// like variables.
-		static const unordered_set<string> macroMarshals =
+		static const unordered_set<string> MacroMarshals =
 			{
 					{"now"},
 					{"event_time"},
@@ -585,109 +564,108 @@ namespace openset
 					{"prev_match"},
 					{"first_match"},
 					{"session_count"},
-					{"session"},
 					{"__internal_init_dict"},
 					{"__internal_init_list"},
 			};
 
 		// Comparatives
-		static const unordered_map<string, opCode_e> operators = {
-					{">=",opCode_e::OPGTE},
-					{"<=",opCode_e::OPLTE},
-					{">",opCode_e::OPGT},
-					{"<",opCode_e::OPLT},
-					{"==",opCode_e::OPEQ},
-					{"is",opCode_e::OPEQ},
-					{ "=",opCode_e::OPEQ },
-					{"!=",opCode_e::OPNEQ},
-					{"<>",opCode_e::OPNEQ},
-					{"not",opCode_e::OPNOT},
-					{"isnot",opCode_e::OPNEQ},
+		static const unordered_map<string, OpCode_e> Operators = {
+					{">=",OpCode_e::OPGTE},
+					{"<=",OpCode_e::OPLTE},
+					{">",OpCode_e::OPGT},
+					{"<",OpCode_e::OPLT},
+					{"==",OpCode_e::OPEQ},
+					{"is",OpCode_e::OPEQ},
+					{ "=",OpCode_e::OPEQ },
+					{"!=",OpCode_e::OPNEQ},
+					{"<>",OpCode_e::OPNEQ},
+					{"not",OpCode_e::OPNOT},
+					{"isnot",OpCode_e::OPNEQ},
 					// {"within",opCode_e::OPWTHN},
 			};
 
-		static const unordered_map<string, opCode_e> mathAssignmentOperators = {
-			{ "+=", opCode_e::MATHADDEQ }, // math operators
-			{ "-=", opCode_e::MATHSUBEQ },
-			{ "*=", opCode_e::MATHMULEQ },
-			{ "/=", opCode_e::MATHDIVEQ },
+		static const unordered_map<string, OpCode_e> MathAssignmentOperators = {
+			{ "+=", OpCode_e::MATHADDEQ }, // math operators
+			{ "-=", OpCode_e::MATHSUBEQ },
+			{ "*=", OpCode_e::MATHMULEQ },
+			{ "/=", OpCode_e::MATHDIVEQ },
 		};
 
-		static const unordered_map<opCode_e, string> operatorsDebug = {
-					{opCode_e::OPGTE, ">="},
-					{opCode_e::OPLTE, "<="},
-					{opCode_e::OPGT, ">"},
-					{opCode_e::OPLT, "<"},
-					{opCode_e::OPEQ, "=="},
-					{opCode_e::OPNEQ, "!="},
-					{opCode_e::OPNOT, "!"}
+		static const unordered_map<OpCode_e, string> OperatorsDebug = {
+					{OpCode_e::OPGTE, ">="},
+					{OpCode_e::OPLTE, "<="},
+					{OpCode_e::OPGT, ">"},
+					{OpCode_e::OPLT, "<"},
+					{OpCode_e::OPEQ, "=="},
+					{OpCode_e::OPNEQ, "!="},
+					{OpCode_e::OPNOT, "!"}
 					// {opCode_e::OPWTHN, "within"}
 			};
 
 		// Math
-		static const unordered_map<string, opCode_e> math =
+		static const unordered_map<string, OpCode_e> Math =
 		{
-				{"+", opCode_e::MATHADD},
-				{"-", opCode_e::MATHSUB},
-				{"*", opCode_e::MATHMUL},
-				{"/", opCode_e::MATHDIV}
+				{"+", OpCode_e::MATHADD},
+				{"-", OpCode_e::MATHSUB},
+				{"*", OpCode_e::MATHMUL},
+				{"/", OpCode_e::MATHDIV}
 		};
 
 		// Conditionals
-		static const unordered_map<string, opCode_e> logicalOperators =
+		static const unordered_map<string, OpCode_e> LogicalOperators =
 			{
-					{"and", opCode_e::LGCAND},
-					{"or", opCode_e::LGCOR},
-					{"in", opCode_e::LGCOR},
-					{"nest_and", opCode_e::LGCNSTAND},
-					{"nest_or", opCode_e::LGCNSTOR},
+					{"and", OpCode_e::LGCAND},
+					{"or", OpCode_e::LGCOR},
+					{"in", OpCode_e::LGCOR},
+					{"nest_and", OpCode_e::LGCNSTAND},
+					{"nest_or", OpCode_e::LGCNSTOR},
 			};
 
-		static const unordered_map<opCode_e, string> logicalOperatorsDebug = {
-					{opCode_e::LGCAND, "and"},
-					{opCode_e::LGCOR, "or"},
+		static const unordered_map<OpCode_e, string> LogicalOperatorsDebug = {
+					{OpCode_e::LGCAND, "and"},
+					{OpCode_e::LGCOR, "or"},
 			};
 
-		static const unordered_map<hintOp_e, string> hintOperatorsDebug = {
-					{hintOp_e::UNSUPPORTED, "UNSUP"},
-					{hintOp_e::PUSH_EQ, "PUSH_EQ"},
-					{hintOp_e::PUSH_NEQ, "PUSH_NEQ"},
-					{hintOp_e::PUSH_GT, "PUSH_GT"},
-					{hintOp_e::PUSH_GTE, "PUSH_GTE"},
-					{hintOp_e::PUSH_LT, "PUSH_LT"},
-					{hintOp_e::PUSH_LTE, "PUSH_LTE"},
-					{hintOp_e::PUSH_PRESENT, "PUSH_PRES"},
-					{hintOp_e::PUSH_NOP, "PUSH_NOP"},
-					{hintOp_e::BIT_OR, "BIT_OR"},
-					{hintOp_e::BIT_AND, "BIT_AND"},
-					{hintOp_e::NST_BIT_OR, "NST_BIT_OR"},
-					{hintOp_e::NST_BIT_AND, "NST_BIT_AND"},
+		static const unordered_map<HintOp_e, string> HintOperatorsDebug = {
+					{HintOp_e::UNSUPPORTED, "UNSUP"},
+					{HintOp_e::PUSH_EQ, "PUSH_EQ"},
+					{HintOp_e::PUSH_NEQ, "PUSH_NEQ"},
+					{HintOp_e::PUSH_GT, "PUSH_GT"},
+					{HintOp_e::PUSH_GTE, "PUSH_GTE"},
+					{HintOp_e::PUSH_LT, "PUSH_LT"},
+					{HintOp_e::PUSH_LTE, "PUSH_LTE"},
+					{HintOp_e::PUSH_PRESENT, "PUSH_PRES"},
+					{HintOp_e::PUSH_NOP, "PUSH_NOP"},
+					{HintOp_e::BIT_OR, "BIT_OR"},
+					{HintOp_e::BIT_AND, "BIT_AND"},
+					{HintOp_e::NST_BIT_OR, "NST_BIT_OR"},
+					{HintOp_e::NST_BIT_AND, "NST_BIT_AND"},
 
 			};
 
-		static const unordered_map<opCode_e, hintOp_e> opToHintOp = {
-					{opCode_e::OPGTE, hintOp_e::PUSH_GTE},
-					{opCode_e::OPLTE, hintOp_e::PUSH_LTE},
-					{opCode_e::OPGT, hintOp_e::PUSH_GT},
-					{opCode_e::OPLT, hintOp_e::PUSH_LT},
-					{opCode_e::OPEQ, hintOp_e::PUSH_EQ},
-					{opCode_e::OPNEQ, hintOp_e::PUSH_NEQ},
-					{opCode_e::OPNOT, hintOp_e::PUSH_NOT},
-					{opCode_e::LGCAND, hintOp_e::BIT_AND},
-					{opCode_e::LGCOR, hintOp_e::BIT_OR},
-					{opCode_e::LGCNSTOR, hintOp_e::NST_BIT_OR},
-					{opCode_e::LGCNSTAND, hintOp_e::NST_BIT_AND},
+		static const unordered_map<OpCode_e, HintOp_e> OpToHintOp = {
+					{OpCode_e::OPGTE, HintOp_e::PUSH_GTE},
+					{OpCode_e::OPLTE, HintOp_e::PUSH_LTE},
+					{OpCode_e::OPGT, HintOp_e::PUSH_GT},
+					{OpCode_e::OPLT, HintOp_e::PUSH_LT},
+					{OpCode_e::OPEQ, HintOp_e::PUSH_EQ},
+					{OpCode_e::OPNEQ, HintOp_e::PUSH_NEQ},
+					{OpCode_e::OPNOT, HintOp_e::PUSH_NOT},
+					{OpCode_e::LGCAND, HintOp_e::BIT_AND},
+					{OpCode_e::LGCOR, HintOp_e::BIT_OR},
+					{OpCode_e::LGCNSTOR, HintOp_e::NST_BIT_OR},
+					{OpCode_e::LGCNSTAND, HintOp_e::NST_BIT_AND},
 			};
 
-		struct hintOp_s
+		struct HintOp_s
 		{
-			hintOp_e op;
+			HintOp_e op;
 			string column;
 			int64_t intValue;
 			string textValue;
 			bool numeric;
 
-			hintOp_s(const hintOp_e op, 
+			HintOp_s(const HintOp_e op, 
 				     const string column, 
 				     const int64_t intValue) :
 				op(op),
@@ -696,7 +674,7 @@ namespace openset
 				numeric(true)
 			{}
 
-			hintOp_s(const hintOp_e op, 
+			HintOp_s(const HintOp_e op, 
 				     const string column, 
 				     const string text) :
 				op(op),
@@ -716,14 +694,14 @@ namespace openset
 				}
 			}
 
-			explicit hintOp_s(const hintOp_e op) :
+			explicit HintOp_s(const HintOp_e op) :
 				op(op),
 				intValue(0),
 				numeric(false)
 			{}
 		};
 
-		using HintOpList = vector<hintOp_s>;
+		using HintOpList = vector<HintOp_s>;
 
 		struct Variable_s
 		{
@@ -731,7 +709,7 @@ namespace openset
 			string alias; // alias
 			string space; // namespace
 			string distinctColumnName{"__action"}; // name of column used for aggregators
-			modifiers_e modifier{modifiers_e::value}; // default is value
+			Modifiers_e modifier{Modifiers_e::value}; // default is value
 			int index{-1}; // index
 			int column{-1}; // column in grid
 			int schemaColumn{-1}; // column in schema
@@ -761,7 +739,7 @@ namespace openset
 			Variable_s(const string actual, 
 					   const string alias,
 			           const string space,
-			           const modifiers_e modifier = modifiers_e::value,
+			           const Modifiers_e modifier = Modifiers_e::value,
 			           const int sortOrder = -1):
 				actual(actual),
 				alias(alias),
@@ -819,14 +797,14 @@ namespace openset
 		// structure fo final build
 		struct Instruction_s
 		{
-			opCode_e op;
+			OpCode_e op;
 			int64_t index;
 			int64_t value;
 			int64_t extra;
 			Debug_s debug;
 
 			Instruction_s(
-				const opCode_e op,
+				const OpCode_e op,
 				const int64_t index,
 				const int64_t value,
 				const int64_t extra,
@@ -839,7 +817,7 @@ namespace openset
 			{}
 
 			Instruction_s(
-				const opCode_e op,
+				const OpCode_e op,
 				const int64_t index,
 				const int64_t value,
 				const int64_t extra) :
@@ -929,33 +907,26 @@ namespace openset
 		using SegmentList = vector<std::string>;
 
 		// struct containing compiled macro
-		struct Macro_S
+		struct Macro_s
 		{
 			Variables_S vars;
 			InstructionList code;
 			HintPairs indexes;
-			bool isSegment;
 			string segmentName;
-			int64_t segmentTTL;
-			int64_t segmentRefresh;
 			SegmentList segments;
 
-			bool useGlobals; // uses global for table
-			bool useCached; // for segments allow use of cached values within TTL
-			bool isSegmentMath; // for segments, the index has the value, script execution not required
-			bool useSessions; // uses session functions, we can cache these
+			int64_t segmentTTL{ -1 };
+			int64_t segmentRefresh{ -1 };
+			int sessionColumn{ -1 };
+			int64_t sessionTime{ 60'000LL * 30LL }; // 30 minutes
 
-			Macro_S() :
-				isSegment(false),
-				segmentTTL(-1),
-				segmentRefresh(-1),
-				useGlobals(false),
-				useCached(false),
-				isSegmentMath(false),
-				useSessions(false)
-			{};
+			bool isSegment{ false };
+			bool useGlobals{ false }; // uses global for table
+			bool useCached{ false }; // for segments allow use of cached values within TTL
+			bool isSegmentMath{ false }; // for segments, the index has the value, script execution not required
+			bool useSessions{ false }; // uses session functions, we can cache these
 		};
 
-		using QueryPairs = vector<pair<string, Macro_S>>;
+		using QueryPairs = vector<pair<string, Macro_s>>;
 	}
 }

--- a/src/querycommon.h
+++ b/src/querycommon.h
@@ -135,7 +135,6 @@ namespace openset
 			marshal_to_days,
 			marshal_get_second,
 			marshal_round_second,
-			marshal_to_second_date,
 			marshal_get_minute,
 			marshal_round_minute,
 			marshal_get_hour,
@@ -157,7 +156,6 @@ namespace openset
 			marshal_iter_move_last,
 			marshal_iter_next,
 			marshal_iter_prev,
-			marshal_iter_event, // not implemented yet
 			marshal_event_count,
 			marshal_iter_within,
 			marshal_iter_between,
@@ -200,8 +198,11 @@ namespace openset
 			marshal_range, // not implemented
 			marshal_str_split,
 			marshal_str_find,
+			marshal_str_rfind,
 			marshal_str_replace,
-			marshal_slice,
+			marshal_str_slice,
+			marshal_str_strip,
+			marshal_url_decode
 		};
 
 		// enum used for query index optimizer
@@ -551,8 +552,11 @@ namespace openset
 					{ "__keys", marshals_e::marshal_keys },
 					{ "__split", marshals_e::marshal_str_split },
 					{ "__find", marshals_e::marshal_str_find },
-					{ "__slice", marshals_e::marshal_slice },
-					{ "range", marshals_e::marshal_range }
+					{ "__rfind", marshals_e::marshal_str_rfind },
+					{ "__slice", marshals_e::marshal_str_slice },
+					{ "__strip", marshals_e::marshal_str_strip},
+					{ "range", marshals_e::marshal_range },
+					{ "url_decode", marshals_e::marshal_url_decode }
 			};
 
 		static const unordered_set<marshals_e> segmentMathMarshals =

--- a/src/queryindexing.cpp
+++ b/src/queryindexing.cpp
@@ -15,7 +15,7 @@ openset::query::Indexing::Indexing() :
 Indexing::~Indexing()
 {}
 
-void Indexing::mount(Table* tablePtr, macro_s& queryMacros, int partitionNumber, int stopAtBit)
+void Indexing::mount(Table* tablePtr, Macro_S& queryMacros, int partitionNumber, int stopAtBit)
 {
 	indexes.clear();
 	table = tablePtr;
@@ -144,8 +144,8 @@ IndexBits Indexing::buildIndex(HintOpList &index, bool &countable)
 				// getBits returns EQ, we doing NOT EQUAL, because all users not
 				// having a value is different than all users who had another
 				// value other than this one (which is what a list would
-				// return) we are going to value that equal NULLCELL
-				if (instruction.numeric && instruction.intValue == NULLCELL)
+				// return) we are going to value that equal NONE
+				if (instruction.numeric && instruction.intValue == NONE)
 				{
 					s.push(getBits(instruction, Attributes::listMode_e::EQ));
 				}

--- a/src/queryindexing.cpp
+++ b/src/queryindexing.cpp
@@ -15,7 +15,7 @@ openset::query::Indexing::Indexing() :
 Indexing::~Indexing()
 {}
 
-void Indexing::mount(Table* tablePtr, Macro_S& queryMacros, int partitionNumber, int stopAtBit)
+void Indexing::mount(Table* tablePtr, Macro_s& queryMacros, int partitionNumber, int stopAtBit)
 {
 	indexes.clear();
 	table = tablePtr;
@@ -69,7 +69,7 @@ IndexBits Indexing::buildIndex(HintOpList &index, bool &countable)
 		- OR all those attributes together and return the 
 		  cumulative result
 	*/
-	auto getBits = [&](hintOp_s& instruction, Attributes::listMode_e mode) -> IndexBits
+	auto getBits = [&](HintOp_s& instruction, Attributes::listMode_e mode) -> IndexBits
 		{
 			auto colInfo = table->getColumns()->getColumn(instruction.column);
 			auto attrList = parts->attributes.getColumnValues(
@@ -108,7 +108,7 @@ IndexBits Indexing::buildIndex(HintOpList &index, bool &countable)
 
 
 	// clean up any trailing NOPs
-	while (index.size() && index.back().op == hintOp_e::PUSH_NOP)
+	while (index.size() && index.back().op == HintOp_e::PUSH_NOP)
 		index.pop_back();
 
 	stack<IndexBits> s;
@@ -118,9 +118,9 @@ IndexBits Indexing::buildIndex(HintOpList &index, bool &countable)
 
 	for (auto& instruction : index)
 	{
-		if (instruction.op == hintOp_e::PUSH_NOP ||
-			instruction.op == hintOp_e::NST_BIT_AND ||
-			instruction.op == hintOp_e::NST_BIT_OR )
+		if (instruction.op == HintOp_e::PUSH_NOP ||
+			instruction.op == HintOp_e::NST_BIT_AND ||
+			instruction.op == HintOp_e::NST_BIT_OR )
 		{
 			countable = false;
 			break;
@@ -134,13 +134,13 @@ IndexBits Indexing::buildIndex(HintOpList &index, bool &countable)
 
 		switch (instruction.op)
 		{
-			case hintOp_e::UNSUPPORTED:
+			case HintOp_e::UNSUPPORTED:
 				break;
-			case hintOp_e::PUSH_EQ:
+			case HintOp_e::PUSH_EQ:
 				s.push(getBits(instruction, Attributes::listMode_e::EQ));
 				++count;
 				break;
-			case hintOp_e::PUSH_NEQ:
+			case HintOp_e::PUSH_NEQ:
 				// getBits returns EQ, we doing NOT EQUAL, because all users not
 				// having a value is different than all users who had another
 				// value other than this one (which is what a list would
@@ -158,34 +158,34 @@ IndexBits Indexing::buildIndex(HintOpList &index, bool &countable)
 				}
 				++count;
 				break;
-			case hintOp_e::PUSH_GT:
+			case HintOp_e::PUSH_GT:
 				s.push(getBits(instruction, Attributes::listMode_e::GT));
 				++count;
 				break;
-			case hintOp_e::PUSH_GTE:
+			case HintOp_e::PUSH_GTE:
 				s.push(getBits(instruction, Attributes::listMode_e::GTE));
 				++count;
 				break;
-			case hintOp_e::PUSH_LT:
+			case HintOp_e::PUSH_LT:
 				s.push(getBits(instruction, Attributes::listMode_e::LT));
 				++count;
 				break;
-			case hintOp_e::PUSH_LTE:
+			case HintOp_e::PUSH_LTE:
 				s.push(getBits(instruction, Attributes::listMode_e::LTE));
 				++count;
 				break;
-			case hintOp_e::PUSH_PRESENT:
+			case HintOp_e::PUSH_PRESENT:
 				s.push(getBits(instruction, Attributes::listMode_e::PRESENT));
 				++count;
 				break;
-			case hintOp_e::PUSH_NOP:
+			case HintOp_e::PUSH_NOP:
 				// these are dummy bits... they simply copy the end of the heap
 				// and push it back onto the heap
 				s.push(IndexBits{});
 				s.top().placeHolder = true;
 				break;
-			case hintOp_e::NST_BIT_OR:
-			case hintOp_e::BIT_OR:
+			case HintOp_e::NST_BIT_OR:
+			case HintOp_e::BIT_OR:
 				// pop two IndexBits objects off the stack
 				right = s.top();
 				s.pop();
@@ -206,8 +206,8 @@ IndexBits Indexing::buildIndex(HintOpList &index, bool &countable)
 					s.push(left);
 				}
 				break;
-			case hintOp_e::NST_BIT_AND:
-			case hintOp_e::BIT_AND:
+			case HintOp_e::NST_BIT_AND:
+			case HintOp_e::BIT_AND:
 				// pop two IndexBits objects off the stack
 				right = s.top();
 				s.pop();

--- a/src/queryindexing.h
+++ b/src/queryindexing.h
@@ -16,7 +16,7 @@ namespace openset
 			using IndexPair = std::tuple<std::string, openset::db::IndexBits, bool>;
 			using IndexList = std::vector<IndexPair>;
 
-			Macro_S macros;
+			Macro_s macros;
 			openset::db::Table* table;
 			openset::db::TablePartitioned* parts;
 			int partition;
@@ -28,7 +28,7 @@ namespace openset
 
 			void mount(
 				openset::db::Table* tablePtr, 
-				Macro_S& queryMacros, 
+				Macro_s& queryMacros, 
 				int partitionNumber, 
 				int stopAtBit);
 

--- a/src/queryindexing.h
+++ b/src/queryindexing.h
@@ -16,7 +16,7 @@ namespace openset
 			using IndexPair = std::tuple<std::string, openset::db::IndexBits, bool>;
 			using IndexList = std::vector<IndexPair>;
 
-			macro_s macros;
+			Macro_S macros;
 			openset::db::Table* table;
 			openset::db::TablePartitioned* parts;
 			int partition;
@@ -28,7 +28,7 @@ namespace openset
 
 			void mount(
 				openset::db::Table* tablePtr, 
-				macro_s& queryMacros, 
+				Macro_S& queryMacros, 
 				int partitionNumber, 
 				int stopAtBit);
 

--- a/src/queryinterpreter.cpp
+++ b/src/queryinterpreter.cpp
@@ -9,7 +9,7 @@
 const int MAX_EXEC_COUNT = 1'000'000'000;
 const int MAX_RECURSE_COUNT = 10;
 
-openset::query::Interpreter::Interpreter(macro_s& macros, interpretMode_e interpretMode):
+openset::query::Interpreter::Interpreter(Macro_S& macros, const InterpretMode_e interpretMode):
 	macros(macros),
 	interpretMode(interpretMode)
 {
@@ -125,7 +125,7 @@ openset::query::SegmentList* openset::query::Interpreter::getSegmentList() const
 	return &macros.segments;
 }
 
-void openset::query::Interpreter::marshal_tally(int paramCount, col_s* columns, int currentRow)
+void openset::query::Interpreter::marshal_tally(const int paramCount, const col_s* columns, const int currentRow)
 {
 
 	if (paramCount <= 0)
@@ -139,8 +139,8 @@ void openset::query::Interpreter::marshal_tally(int paramCount, col_s* columns, 
 
 		// if any of these params are undefined, exit
 		if (stackPtr->typeof() != cvar::valueType::STR &&
-			*stackPtr == NULLCELL)
-			params[i] = NULLCELL;
+			*stackPtr == NONE)
+			params[i] = NONE;
 		else
 			params[i] = std::move(*stackPtr);
 	}
@@ -173,7 +173,7 @@ void openset::query::Interpreter::marshal_tally(int paramCount, col_s* columns, 
 			case cvar::valueType::BOOL:
 				return value.getBool() ? 1 : 0;
 			default:
-				return NULLCELL;
+				return NONE;
 		}
 	};
 	
@@ -208,9 +208,9 @@ void openset::query::Interpreter::marshal_tally(int paramCount, col_s* columns, 
 			switch (resCol.modifier)
 			{
 				case modifiers_e::sum:
-					if (columns->cols[resCol.column] != NULLCELL)
+					if (columns->cols[resCol.column] != NONE)
 					{
-						if (resultColumns->columns[resultIndex].value == NULLCELL)
+						if (resultColumns->columns[resultIndex].value == NONE)
 							resultColumns->columns[resultIndex].value = columns->cols[resCol.column];
 						else
 							resultColumns->columns[resultIndex].value += columns->cols[resCol.column];
@@ -218,23 +218,23 @@ void openset::query::Interpreter::marshal_tally(int paramCount, col_s* columns, 
 					break;
 
 				case modifiers_e::min:
-					if (columns->cols[resCol.column] != NULLCELL &&
-							(resultColumns->columns[resultIndex].value == NULLCELL ||
+					if (columns->cols[resCol.column] != NONE &&
+							(resultColumns->columns[resultIndex].value == NONE ||
 							 resultColumns->columns[resultIndex].value > columns->cols[resCol.column]))
 						resultColumns->columns[resultIndex].value = columns->cols[resCol.column];
 					break;
 
 				case modifiers_e::max:
-					if (columns->cols[resCol.column] != NULLCELL &&
-							(resultColumns->columns[resultIndex].value == NULLCELL ||
+					if (columns->cols[resCol.column] != NONE &&
+							(resultColumns->columns[resultIndex].value == NONE ||
 							 resultColumns->columns[resultIndex].value < columns->cols[resCol.column]))
 						resultColumns->columns[resultIndex].value = columns->cols[resCol.column];
 					break;
 
 				case modifiers_e::avg:
-					if (columns->cols[resCol.column] != NULLCELL)
+					if (columns->cols[resCol.column] != NONE)
 					{
-						if (resultColumns->columns[resultIndex].value == NULLCELL)
+						if (resultColumns->columns[resultIndex].value == NONE)
 						{
 							resultColumns->columns[resultIndex].value = columns->cols[resCol.column];
 							resultColumns->columns[resultIndex].count = 1;
@@ -247,9 +247,9 @@ void openset::query::Interpreter::marshal_tally(int paramCount, col_s* columns, 
 					}
 					break;
 				case modifiers_e::count:
-					if (columns->cols[resCol.column] != NULLCELL)
+					if (columns->cols[resCol.column] != NONE)
 					{
-						if (resultColumns->columns[resultIndex].value == NULLCELL)
+						if (resultColumns->columns[resultIndex].value == NONE)
 							resultColumns->columns[resultIndex].value = 1;
 						else
 							resultColumns->columns[resultIndex].value++;
@@ -261,7 +261,7 @@ void openset::query::Interpreter::marshal_tally(int paramCount, col_s* columns, 
 					break;
 
 				case modifiers_e::var:
-					if (resultColumns->columns[resultIndex].value == NULLCELL)
+					if (resultColumns->columns[resultIndex].value == NONE)
 						resultColumns->columns[resultIndex].value = fixToInt(resCol.value);
 					else
 						resultColumns->columns[resultIndex].value += fixToInt(resCol.value);
@@ -286,7 +286,7 @@ void openset::query::Interpreter::marshal_tally(int paramCount, col_s* columns, 
     {
 
 		if (item.typeof() != cvar::valueType::STR &&
-			item == NULLCELL)
+			item == NONE)
 			break;
 
 	    rowKey.key[depth] = fixToInt(item);
@@ -307,7 +307,7 @@ void openset::query::Interpreter::marshal_tally(int paramCount, col_s* columns, 
 
 }
 
-void openset::query::Interpreter::marshal_schedule(int paramCount)
+void openset::query::Interpreter::marshal_schedule(const int paramCount)
 {
 	if (paramCount != 2)
 	{
@@ -315,7 +315,7 @@ void openset::query::Interpreter::marshal_schedule(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"schedule doesn't have the correct number of parameters");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -329,11 +329,11 @@ void openset::query::Interpreter::marshal_schedule(int paramCount)
 	if (schedule_cb)
 		schedule_cb(functionHash, scheduleAt);
 
-	*stackPtr = NULLCELL; // push
+	*stackPtr = NONE; // push
 	++stackPtr;
 }
 
-void openset::query::Interpreter::marshal_emit(int paramCount)
+void openset::query::Interpreter::marshal_emit(const int paramCount)
 {
 	if (paramCount != 1)
 	{
@@ -341,13 +341,13 @@ void openset::query::Interpreter::marshal_emit(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"emit doesn't have the correct number of parameters");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
 
 	jobState = true;
-	loopState = loopState_e::in_exit;
+	loopState = LoopState_e::in_exit;
 
 	--stackPtr;
 	auto emitMessage = *stackPtr; // pop
@@ -355,7 +355,7 @@ void openset::query::Interpreter::marshal_emit(int paramCount)
 	if (emit_cb)
 		emit_cb(emitMessage);
 
-	*stackPtr = NULLCELL; // push
+	*stackPtr = NONE; // push
 	++stackPtr;
 }
 
@@ -418,7 +418,7 @@ void __nestItercvar(const cvar* cvariable, string& result)
 	}
 }
 
-void openset::query::Interpreter::marshal_log(int paramCount)
+void openset::query::Interpreter::marshal_log(const int paramCount)
 {
 	vector<cvar> params;
 	for (auto i = 0; i < paramCount; ++i)
@@ -444,11 +444,11 @@ void openset::query::Interpreter::marshal_log(int paramCount)
 
 	cout << endl;
 
-	*stackPtr = NULLCELL;
+	*stackPtr = NONE;
 	++stackPtr;
 }
 
-void openset::query::Interpreter::marshal_break(int paramCount)
+void openset::query::Interpreter::marshal_break(const int paramCount)
 {
 	if (paramCount > 1)
 	{
@@ -456,7 +456,7 @@ void openset::query::Interpreter::marshal_break(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"break requires: no params, #, 'top' or 'all'");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -469,12 +469,12 @@ void openset::query::Interpreter::marshal_break(int paramCount)
 		if (param == "all"s)
 		{
 			breakDepth = nestDepth;
-			loopState = loopState_e::in_break;
+			loopState = LoopState_e::in_break;
 		}
 		else if (param == "top"s)
 		{
 			breakDepth = nestDepth - 1;
-			loopState = loopState_e::in_break;
+			loopState = LoopState_e::in_break;
 		}
 		else
 		{
@@ -488,20 +488,20 @@ void openset::query::Interpreter::marshal_break(int paramCount)
 				return;
 			}
 
-			loopState = loopState_e::in_break;
+			loopState = LoopState_e::in_break;
 		}
 	}
 	else
 	{
 		breakDepth = 1;
-		loopState = loopState_e::in_break;
+		loopState = LoopState_e::in_break;
 	}
 
-	*stackPtr = NULLCELL;
+	*stackPtr = NONE;
 	++stackPtr;
 }
 
-void openset::query::Interpreter::marshal_dt_within(int paramCount, int64_t rowStamp)
+void openset::query::Interpreter::marshal_dt_within(const int paramCount, const int64_t rowStamp)
 {
 	if (paramCount != 2)
 	{
@@ -509,7 +509,7 @@ void openset::query::Interpreter::marshal_dt_within(int paramCount, int64_t rowS
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"date within bad parameter count");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -525,7 +525,7 @@ void openset::query::Interpreter::marshal_dt_within(int paramCount, int64_t rowS
 	++stackPtr;
 }
 
-void openset::query::Interpreter::marshal_dt_between(int paramCount, int64_t rowStamp)
+void openset::query::Interpreter::marshal_dt_between(const int paramCount, const int64_t rowStamp)
 {
 	if (paramCount != 2)
 	{
@@ -533,7 +533,7 @@ void openset::query::Interpreter::marshal_dt_between(int paramCount, int64_t row
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"between clause requires two parameters");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -558,7 +558,7 @@ void openset::query::Interpreter::marshal_dt_between(int paramCount, int64_t row
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"date error in between statement");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -573,7 +573,7 @@ void openset::query::Interpreter::marshal_dt_between(int paramCount, int64_t row
 	++stackPtr;
 }
 
-void openset::query::Interpreter::marshal_bucket(int paramCount)
+void openset::query::Interpreter::marshal_bucket(const int paramCount)
 {
 	if (paramCount != 2)
 	{
@@ -581,7 +581,7 @@ void openset::query::Interpreter::marshal_bucket(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"bucket takes two parameters");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -606,7 +606,7 @@ void openset::query::Interpreter::marshal_bucket(int paramCount)
 	++stackPtr;
 }
 
-void openset::query::Interpreter::marshal_round(int paramCount)
+void openset::query::Interpreter::marshal_round(const int paramCount)
 {
 	if (paramCount != 1 && paramCount != 2)
 	{
@@ -614,7 +614,7 @@ void openset::query::Interpreter::marshal_round(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"round takes one or two parameters");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -631,7 +631,7 @@ void openset::query::Interpreter::marshal_round(int paramCount)
 	*(stackPtr - 1) = round((stackPtr - 1)->getDouble() * power) / power;
 }
 
-void openset::query::Interpreter::marshal_fix(int paramCount)
+void openset::query::Interpreter::marshal_fix(const int paramCount)
 {
 	if (paramCount != 2)
 	{
@@ -639,7 +639,7 @@ void openset::query::Interpreter::marshal_fix(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"fix takes two parameters");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -671,7 +671,7 @@ void openset::query::Interpreter::marshal_fix(int paramCount)
 }
 
 
-void openset::query::Interpreter::marshal_makeDict(int paramCount)
+void openset::query::Interpreter::marshal_makeDict(const int paramCount)
 {
 	cvar output;
 	output.dict();
@@ -695,7 +695,7 @@ void openset::query::Interpreter::marshal_makeDict(int paramCount)
 	++stackPtr;
 }
 
-void openset::query::Interpreter::marshal_makeList(int paramCount)
+void openset::query::Interpreter::marshal_makeList(const int paramCount)
 {
 	cvar output;
 	output.list();
@@ -711,7 +711,7 @@ void openset::query::Interpreter::marshal_makeList(int paramCount)
 	++stackPtr;
 }
 
-void openset::query::Interpreter::marshal_makeSet(int paramCount)
+void openset::query::Interpreter::marshal_makeSet(const int paramCount)
 {
 	cvar output;
 	output.set();
@@ -728,7 +728,7 @@ void openset::query::Interpreter::marshal_makeSet(int paramCount)
 }
 
 
-void openset::query::Interpreter::marshal_population(int paramCount)
+void openset::query::Interpreter::marshal_population(const int paramCount)
 {
 	if (paramCount != 1)
 	{
@@ -736,7 +736,7 @@ void openset::query::Interpreter::marshal_population(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"compliment takes one parameter");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -759,7 +759,7 @@ void openset::query::Interpreter::marshal_population(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::set_math_param_invalid,
 			"compliment - set could not be found");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -771,7 +771,7 @@ void openset::query::Interpreter::marshal_population(int paramCount)
 		delete aBits;
 }
 
-void openset::query::Interpreter::marshal_intersection(int paramCount)
+void openset::query::Interpreter::marshal_intersection(const int paramCount)
 {
 	if (paramCount != 2)
 	{
@@ -779,7 +779,7 @@ void openset::query::Interpreter::marshal_intersection(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"intersection takes two parameters");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -806,7 +806,7 @@ void openset::query::Interpreter::marshal_intersection(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::set_math_param_invalid,
 			"intersection - set could not be found");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -824,7 +824,7 @@ void openset::query::Interpreter::marshal_intersection(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::set_math_param_invalid,
 			"intersection - set could not be found");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -834,7 +834,7 @@ void openset::query::Interpreter::marshal_intersection(int paramCount)
 	bits->opAnd(*bBits);
 }
 
-void openset::query::Interpreter::marshal_union(int paramCount)
+void openset::query::Interpreter::marshal_union(const int paramCount)
 {
 	if (paramCount != 2)
 	{
@@ -842,7 +842,7 @@ void openset::query::Interpreter::marshal_union(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"union takes two parameters");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -869,7 +869,7 @@ void openset::query::Interpreter::marshal_union(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::set_math_param_invalid,
 			"compliment - set could not be found");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -888,7 +888,7 @@ void openset::query::Interpreter::marshal_union(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::set_math_param_invalid,
 			"compliment - set could not be found");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -903,7 +903,7 @@ void openset::query::Interpreter::marshal_union(int paramCount)
 		delete bBits;
 }
 
-void openset::query::Interpreter::marshal_compliment(int paramCount)
+void openset::query::Interpreter::marshal_compliment(const int paramCount)
 {
 	if (paramCount != 1)
 	{
@@ -911,7 +911,7 @@ void openset::query::Interpreter::marshal_compliment(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"compliment takes one parameter");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -934,7 +934,7 @@ void openset::query::Interpreter::marshal_compliment(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::set_math_param_invalid,
 			"compliment - set could not be found");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -947,7 +947,7 @@ void openset::query::Interpreter::marshal_compliment(int paramCount)
 		delete aBits;
 }
 
-void openset::query::Interpreter::marshal_difference(int paramCount)
+void openset::query::Interpreter::marshal_difference(const int paramCount)
 {
 	if (paramCount != 2)
 	{
@@ -955,7 +955,7 @@ void openset::query::Interpreter::marshal_difference(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::sdk_param_count,
 			"difference takes two parameters");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -982,7 +982,7 @@ void openset::query::Interpreter::marshal_difference(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::set_math_param_invalid,
 			"compliment - set could not be found");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -1001,7 +1001,7 @@ void openset::query::Interpreter::marshal_difference(int paramCount)
 			errors::errorClass_e::run_time,
 			errors::errorCode_e::set_math_param_invalid,
 			"compliment - set could not be found");
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -1016,7 +1016,125 @@ void openset::query::Interpreter::marshal_difference(int paramCount)
 		delete bBits;
 }
 
-string openset::query::Interpreter::getLiteral(int64_t id) const
+void openset::query::Interpreter::marshal_slice(const int paramCount)
+{
+	if (paramCount != 3)
+		throw std::runtime_error("slice [:] malformed");
+	if ((stackPtr - 3)->typeof() != cvar::valueType::REF)
+		throw std::runtime_error("slice [:] first parameter must be reference type");
+
+	const auto reference = stackPtr - 3;
+	auto startIndex = (stackPtr - 2)->getInt64();
+	auto endIndex = (stackPtr - 1)->getInt64();
+
+	stackPtr -= 2; // we will return our result at this position
+
+	// local function to sort our missing, negative, or out of range indexes
+	const auto fixIndexes = [](size_t valueLength, int64_t& startIndex, int64_t& endIndex)
+	{
+		if (startIndex == NONE)
+			startIndex = 0;
+		else if (startIndex < 0)
+			startIndex = valueLength + startIndex;
+
+		if (endIndex == NONE)
+			endIndex = valueLength;
+		else if (endIndex < 0)
+			endIndex = valueLength + endIndex;
+
+		if (endIndex < 0)
+			endIndex = 0;
+		if (endIndex > valueLength)
+			endIndex = valueLength;
+		if (startIndex < 0)
+			startIndex = 0;
+		if (startIndex > valueLength)
+			startIndex = valueLength;
+
+		// we will swap for a valid range if they are reversed for whatever reason
+		if (endIndex < startIndex)
+			std::swap(startIndex, endIndex);
+
+	};
+
+	const auto refType = reference->getReference()->typeof();
+
+	if (refType == cvar::valueType::DICT || refType == cvar::valueType::SET)
+		throw std::runtime_error("slice [:] expecting list, string or convertable type");
+
+	// SET and DICT will merge, LIST will append, so you can append objects
+	if (refType == cvar::valueType::LIST)
+	{
+		const auto value = reference->getReference()->getList();
+		const auto valueLength = value->size();
+		
+		fixIndexes(valueLength, startIndex, endIndex);
+
+		cvar result(cvar::valueType::LIST);
+		auto resultList = result.getList();
+
+		resultList->insert(resultList->begin(), value->begin() + startIndex, value->begin() + endIndex);
+		*(stackPtr - 1) = std::move(result);
+	}
+	else
+	{
+		auto value = reference->getReference()->getString(); // convert type of needed
+		const auto valueLength = value.length();
+
+		fixIndexes(valueLength, startIndex, endIndex);
+
+		cvar result(cvar::valueType::STR);
+		const auto resultString = result.getStringPtr(); // grab the actual pointer to the string in the cvar
+
+		*resultString = value.substr(startIndex, endIndex - startIndex);
+		*(stackPtr - 1) = std::move(result);
+	}
+		
+}
+
+void openset::query::Interpreter::marshal_find(const int paramCount)
+{
+	if (paramCount < 2)
+		throw std::runtime_error("find malformed");
+	if ((stackPtr - paramCount)->typeof() != cvar::valueType::REF)
+		throw std::runtime_error(".find first parameter must be reference type");
+
+	auto count = paramCount;
+
+	size_t length = 0;
+	if (count == 4)
+	{
+		length = (stackPtr - 1)->getInt32();
+		--stackPtr;
+		--count;
+	}
+
+	size_t firstPos = 0;
+	if (count == 3)
+	{
+		firstPos = (stackPtr - 1)->getInt32();
+		--stackPtr;
+	}
+	
+	const auto reference = stackPtr - 2;
+	const auto lookFor = stackPtr - 1;
+	const auto refType = reference->getReference()->typeof();
+
+	auto str = reference->getReference()->getString();
+
+	// python allows a second index, C++ takes a length, lets convert
+	if (length)
+		str = str.substr(0, length);
+	
+	if (refType == cvar::valueType::DICT || refType == cvar::valueType::SET || refType == cvar::valueType::LIST)
+		throw std::runtime_error(".find expecting string or convertable type");
+
+	const auto pos = str.find(lookFor->getString().c_str(), firstPos);
+	
+	*(stackPtr - 1) = (pos == std::string::npos) ? -1 : static_cast<int32_t>(pos);
+}
+
+string openset::query::Interpreter::getLiteral(const int64_t id) const
 {
 	for (auto& i: macros.vars.literals)
 	{
@@ -1026,7 +1144,7 @@ string openset::query::Interpreter::getLiteral(int64_t id) const
 	return "";
 }
 
-bool openset::query::Interpreter::marshal(instruction_s* inst, int& currentRow)
+bool openset::query::Interpreter::marshal(Instruction_s* inst, int& currentRow)
 {
 	// index maps to function in the enumerator marshals_e
 	// extra maps to the param count (items on stack)
@@ -1037,11 +1155,11 @@ bool openset::query::Interpreter::marshal(instruction_s* inst, int& currentRow)
 	{
 	case marshals_e::marshal_tally:
 	{
-		if (interpretMode == interpretMode_e::count)
+		if (interpretMode == InterpretMode_e::count)
 		{
 			if (bits)
 				bits->bitSet(linid);
-			loopState = loopState_e::in_exit;
+			loopState = LoopState_e::in_exit;
 			*stackPtr = 0;
 			++stackPtr;
 			return true;
@@ -1194,13 +1312,13 @@ bool openset::query::Interpreter::marshal(instruction_s* inst, int& currentRow)
 			if (nestDepth)
 			{
 				breakDepth = 1;
-				loopState = loopState_e::in_break;
+				loopState = LoopState_e::in_break;
 				*stackPtr = 0;
 				++stackPtr;
 			}
 			else
 			{
-				loopState = loopState_e::in_exit;
+				loopState = LoopState_e::in_exit;
 				*stackPtr = 0;
 				++stackPtr;
 			}
@@ -1263,7 +1381,7 @@ bool openset::query::Interpreter::marshal(instruction_s* inst, int& currentRow)
 		marshal_break(inst->extra);
 		break;
 	case marshals_e::marshal_continue:
-		loopState = loopState_e::in_continue;
+		loopState = LoopState_e::in_continue;
 		*stackPtr = 0;
 		++stackPtr;
 		break;
@@ -1281,7 +1399,7 @@ bool openset::query::Interpreter::marshal(instruction_s* inst, int& currentRow)
 		debugLog.push_back(*stackPtr);
 		break;
 	case marshals_e::marshal_exit:
-		loopState = loopState_e::in_exit;
+		loopState = LoopState_e::in_exit;
 		*stackPtr = 0;
 		++stackPtr;
 		--recursion;
@@ -1391,7 +1509,7 @@ bool openset::query::Interpreter::marshal(instruction_s* inst, int& currentRow)
 			{
 				if (!var->getList() || var->getList()->size() == 0)
 				{
-					*res = NULLCELL;
+					*res = NONE;
 					break;
 				}
 				*res = std::move(var->getList()->back());
@@ -1401,7 +1519,7 @@ bool openset::query::Interpreter::marshal(instruction_s* inst, int& currentRow)
 			{
 				if (!var->getDict() || var->getDict()->size() == 0)
 				{
-					*res = NULLCELL;
+					*res = NONE;
 					break;
 				}
 				auto value = var->getDict()->begin();
@@ -1413,7 +1531,7 @@ bool openset::query::Interpreter::marshal(instruction_s* inst, int& currentRow)
 			{
 				if (!var->getSet() || var->getSet()->size() == 0)
 				{
-					*res = NULLCELL;
+					*res = NONE;
 					break;
 				}
 				auto value = *var->getSet()->begin();
@@ -1468,6 +1586,18 @@ bool openset::query::Interpreter::marshal(instruction_s* inst, int& currentRow)
 
 		break;
 
+	case marshals_e::marshal_to_second_date: break;
+	case marshals_e::marshal_iter_event: break;
+	case marshals_e::marshal_session: break;
+	case marshals_e::marshal_session_count: break;
+	case marshals_e::marshal_str_split: break;
+	case marshals_e::marshal_str_find: 
+		marshal_find(inst->extra);
+		break;
+	case marshals_e::marshal_slice:
+		marshal_slice(inst->extra);
+		break;
+
 	default:
 		error.set(
 			errors::errorClass_e::run_time,
@@ -1480,13 +1610,13 @@ bool openset::query::Interpreter::marshal(instruction_s* inst, int& currentRow)
 	return false; 
 }
 
-void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
+void openset::query::Interpreter::opRunner(Instruction_s* inst, int currentRow)
 {
 	// count allows for now row pointer, and no mounted person
-	if ((!rows || rows->empty()) && interpretMode != interpretMode_e::count)
+	if ((!rows || rows->empty()) && interpretMode != InterpretMode_e::count)
 	{
-		loopState = loopState_e::in_exit;
-		*stackPtr = NULLCELL;
+		loopState = LoopState_e::in_exit;
+		*stackPtr = NONE;
 		++stackPtr;
 		return;
 	}
@@ -1500,16 +1630,16 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 			errors::errorCode_e::recursion,
 			"nesting depth was: " + to_string(recursion),
 			lastDebug->toStrShort());
-		loopState = loopState_e::in_exit;
+		loopState = LoopState_e::in_exit;
 
-		*stackPtr = NULLCELL;
+		*stackPtr = NONE;
 		++stackPtr;
 
 		--recursion;
 		return;
 	}
 
-	while (loopState == loopState_e::run && !error.inError())
+	while (loopState == LoopState_e::run && !error.inError())
 	{
 		// tracks the last known script line number
 		if (inst->debug.number)
@@ -1525,7 +1655,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 				lastDebug->toStrShort());
 			loopState = loopState_e::in_exit;
 
-			*stackPtr = NULLCELL;
+			*stackPtr = NONE;
 			++stackPtr;
 
 			--recursion;
@@ -1543,7 +1673,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 				switch (macros.vars.tableVars[inst->index].schemaType)
 				{
 					case columnTypes_e::freeColumn:
-						*stackPtr = NULLCELL;
+						*stackPtr = NONE;
 						break;
 					case columnTypes_e::intColumn:
 						*stackPtr = (*rows)[currentRow]->cols[macros.vars.tableVars[inst->index].column];
@@ -1617,7 +1747,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 					}
 
 					// this is the value
-					*stackPtr = std::move(tcvar ? *tcvar : cvar{NULLCELL});
+					*stackPtr = std::move(tcvar ? *tcvar : cvar{NONE});
 					++stackPtr;
 				}
 				break;
@@ -1674,7 +1804,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 				break;
 			case opCode_e::PSHLITNUL:
 				// push a floating point value
-				*stackPtr = NULLCELL;
+				*stackPtr = NONE;
 				++stackPtr;
 				break;
 			case opCode_e::POPUSROBJ:
@@ -1759,7 +1889,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 
 				--stackPtr;
 
-				//if (stackPtr->getInt64() != NULLCELL && *stackPtr)
+				//if (stackPtr->getInt64() != NONE && *stackPtr)
 				if (stackPtr->isEvalTrue())
 				{
 					// PASSED - run the code block (recursive)
@@ -1811,7 +1941,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 
 						for (auto& x : *from)
 						{
-							if (loopState == loopState_e::in_exit || error.inError())
+							if (loopState == LoopState_e::in_exit || error.inError())
 							{
 								*stackPtr = 0;
 								++stackPtr;
@@ -1832,11 +1962,11 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 								&macros.code.front() + inst->index,
 								currentRow);
 
-							if (loopState == loopState_e::in_break)
+							if (loopState == LoopState_e::in_break)
 							{
 								if (breakDepth == 1 || nestDepth == 1)
 								{
-									loopState = loopState_e::run;
+									loopState = LoopState_e::run;
 								}
 								else
 								{
@@ -1853,8 +1983,8 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 								return;
 							}
 
-							if (loopState == loopState_e::in_continue)
-								loopState = loopState_e::run; // no actual action, we are going to loop anyways
+							if (loopState == LoopState_e::in_continue)
+								loopState = LoopState_e::run; // no actual action, we are going to loop anyways
 						}
 
 						// out of loop, decrement nest 
@@ -1866,7 +1996,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 
 						for (auto& x: *from)
 						{
-							if (loopState == loopState_e::in_exit || error.inError())
+							if (loopState == LoopState_e::in_exit || error.inError())
 							{
 								*stackPtr = 0;
 								++stackPtr;
@@ -1884,11 +2014,11 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 								&macros.code.front() + inst->index,
 								currentRow);
 
-							if (loopState == loopState_e::in_break)
+							if (loopState == LoopState_e::in_break)
 							{
 								if (breakDepth == 1 || nestDepth == 1)
 								{
-									loopState = loopState_e::run;
+									loopState = LoopState_e::run;
 								}
 								else
 								{
@@ -1905,8 +2035,8 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 								return;
 							}
 
-							if (loopState == loopState_e::in_continue)
-								loopState = loopState_e::run; // no actual action, we are going to loop anyways
+							if (loopState == LoopState_e::in_continue)
+								loopState = LoopState_e::run; // no actual action, we are going to loop anyways
 						}
 					}
 					else if (source.typeof() == cvar::valueType::SET)
@@ -1915,7 +2045,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 
 						for (auto& x : *from)
 						{
-							if (loopState == loopState_e::in_exit || error.inError())
+							if (loopState == LoopState_e::in_exit || error.inError())
 							{
 								*stackPtr = 0;
 								++stackPtr;
@@ -1933,11 +2063,11 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 								&macros.code.front() + inst->index,
 								currentRow);
 
-							if (loopState == loopState_e::in_break)
+							if (loopState == LoopState_e::in_break)
 							{
 								if (breakDepth == 1 || nestDepth == 1)
 								{
-									loopState = loopState_e::run;
+									loopState = LoopState_e::run;
 								}
 								else
 								{
@@ -1954,8 +2084,8 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 								return;
 							}
 
-							if (loopState == loopState_e::in_continue)
-								loopState = loopState_e::run; // no actual action, we are going to loop anyways
+							if (loopState == LoopState_e::in_continue)
+								loopState = LoopState_e::run; // no actual action, we are going to loop anyways
 						}
 					}
 					else
@@ -1964,7 +2094,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 							errors::errorClass_e::run_time,
 							errors::errorCode_e::iteration_error,
 							inst->debug.toStr());
-						loopState = loopState_e::in_exit;
+						loopState = LoopState_e::in_exit;
 						--recursion;
 						return;
 					}
@@ -1990,7 +2120,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 					{
 						//++loopCount;
 
-						if (loopState == loopState_e::in_exit || error.inError())
+						if (loopState == LoopState_e::in_exit || error.inError())
 						{
 							*stackPtr = 0;
 							++stackPtr;
@@ -2030,7 +2160,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 									errors::errorClass_e::run_time,
 									errors::errorCode_e::iteration_error,
 									inst->debug.toStr());
-								loopState = loopState_e::in_exit;
+								loopState = LoopState_e::in_exit;
 								--recursion;
 								return;
 							}
@@ -2048,11 +2178,11 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 									currentRow);
 						}
 
-						if (loopState == loopState_e::in_break)
+						if (loopState == LoopState_e::in_break)
 						{
 							if (breakDepth == 1 || nestDepth == 1)
 							{
-								loopState = loopState_e::run;
+								loopState = LoopState_e::run;
 							}
 							else
 							{
@@ -2070,8 +2200,8 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 						}
 
 						// no actual action, we are going to loop anyways
-						if (loopState == loopState_e::in_continue)
-							loopState = loopState_e::run;
+						if (loopState == LoopState_e::in_continue)
+							loopState = LoopState_e::run;
 					}
 
 					matchStampPrev.pop_back();
@@ -2280,17 +2410,17 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 				break;
 			case opCode_e::OPNOT:
 				--stackPtr;
-				*stackPtr = ((*stackPtr).typeof() == cvar::valueType::BOOL && *stackPtr && *stackPtr != NULLCELL) ? false : true;
+				*stackPtr = ((*stackPtr).typeof() == cvar::valueType::BOOL && *stackPtr && *stackPtr != NONE) ? false : true;
 				++stackPtr;
 				break;
 			case opCode_e::LGCAND:
 				// AND last two items on stack
 				--stackPtr;
 				//right = *stackPtr;
-				if (stackPtr->typeof() != cvar::valueType::BOOL && *stackPtr == NULLCELL)
+				if (stackPtr->typeof() != cvar::valueType::BOOL && *stackPtr == NONE)
 					*stackPtr = false;
 				--stackPtr;
-				if ((*stackPtr).typeof() != cvar::valueType::BOOL && *stackPtr == NULLCELL)
+				if ((*stackPtr).typeof() != cvar::valueType::BOOL && *stackPtr == NONE)
 					*stackPtr = false;
 				*stackPtr = (*stackPtr && *(stackPtr + 1));
 				++stackPtr;
@@ -2299,10 +2429,10 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 				// AND last two items on stack
 				--stackPtr;
 				//right = *stackPtr;
-				if (stackPtr->typeof() != cvar::valueType::BOOL && *stackPtr == NULLCELL)
+				if (stackPtr->typeof() != cvar::valueType::BOOL && *stackPtr == NONE)
 					*stackPtr = false;
 				--stackPtr;
-				if ((*stackPtr).typeof() != cvar::valueType::BOOL && *stackPtr == NULLCELL)
+				if ((*stackPtr).typeof() != cvar::valueType::BOOL && *stackPtr == NONE)
 					*stackPtr = false;
 
 				*stackPtr = (*stackPtr || *(stackPtr + 1));
@@ -2329,7 +2459,7 @@ void openset::query::Interpreter::opRunner(instruction_s* inst, int currentRow)
 			case opCode_e::TERM:
 				// script is complete, exit all nested
 				// loops
-				loopState = loopState_e::in_exit;
+				loopState = LoopState_e::in_exit;
 				*stackPtr = 0;
 				++stackPtr;
 				--recursion;
@@ -2390,7 +2520,7 @@ void openset::query::Interpreter::execReset()
 	recursion = 0;
 	eventCount = -1;
 	jobState = false;
-	loopState = loopState_e::run;
+	loopState = LoopState_e::run;
 	stackPtr = stack;
 	matchStampPrev.clear();
 	eventDistinct.clear();

--- a/src/queryinterpreter.h
+++ b/src/queryinterpreter.h
@@ -20,14 +20,14 @@ namespace openset
 {
 	namespace query
 	{
-		enum class interpretMode_e: int
+		enum class InterpretMode_e: int
 		{
 			query,
 			job,
 			count
 		};
 
-		enum class loopState_e : int
+		enum class LoopState_e : int
 		{
 			run,
 			in_break,
@@ -40,15 +40,15 @@ namespace openset
 		using DebugLog = vector<cvar>;
 		using BitMap = unordered_map<string, IndexBits*>;
 
-		struct stackFrame_s
+		struct StackFrame_s
 		{
 			// data
 			int64_t currentRow;
 			int64_t iterCount;
 
-			explicit stackFrame_s(
+			explicit StackFrame_s(
 				//instruction_s* executionPtr,
-				stackFrame_s* lastFrame):
+				StackFrame_s* lastFrame):
 				//execPtr(executionPtr),
 				currentRow(0),
 				iterCount(0)
@@ -61,7 +61,7 @@ namespace openset
 				}
 			}
 
-			stackFrame_s(stackFrame_s&& other) noexcept
+			StackFrame_s(StackFrame_s&& other) noexcept
 			{
 				currentRow = other.currentRow;
 				iterCount = other.iterCount;
@@ -77,7 +77,7 @@ namespace openset
 			const int64_t breakTopHash = MakeHash("top");
 
 			// execution
-			macro_s& macros;
+			Macro_S& macros;
 			cvar* stack;
 			cvar* stackPtr;
 
@@ -114,8 +114,8 @@ namespace openset
 			vector<int64_t> matchStampPrev{ 0 };
 
 			// switches
-			interpretMode_e interpretMode{ interpretMode_e::query };
-			loopState_e loopState{ loopState_e::run }; // run, continue, break, exit
+			InterpretMode_e interpretMode{ InterpretMode_e::query };
+			LoopState_e loopState{ LoopState_e::run }; // run, continue, break, exit
 			bool isConfigured{ false };
 			bool jobState{ false };
 
@@ -144,8 +144,8 @@ namespace openset
 			Debug_s* lastDebug{ nullptr };
 
 			explicit Interpreter(
-				macro_s& macros,
-				interpretMode_e interpretMode = interpretMode_e::query);
+				Macro_S& macros,
+				const InterpretMode_e interpretMode = InterpretMode_e::query);
 
 			~Interpreter();
 
@@ -156,7 +156,10 @@ namespace openset
 			vector<string> getReferencedColumns() const;
 			void mount(Person* person);
 
-			static constexpr bool within(int64_t compStamp, int64_t rowStamp, int64_t milliseconds)
+			static constexpr bool within(
+				const int64_t compStamp, 
+				const int64_t rowStamp, 
+				const int64_t milliseconds)
 			{
 				return (rowStamp >= compStamp - milliseconds &&
 					rowStamp <= compStamp + milliseconds);
@@ -164,33 +167,36 @@ namespace openset
 
 			SegmentList* getSegmentList() const;
 
-			void marshal_tally(int paramCount, col_s* columns, int currentRow);
+			void marshal_tally(const int paramCount, const col_s* columns, const int currentRow);
 
-			void marshal_schedule(int paramCount);
-			void marshal_emit(int paramCount);
-			void marshal_log(int paramCount);
-			void marshal_break(int paramCount);
-			void marshal_dt_within(int paramCount, int64_t rowStamp);
-			void marshal_dt_between(int paramCount, int64_t rowStamp);
-			void marshal_bucket(int paramCount);
-			void marshal_round(int paramCount);
-			void marshal_fix(int paramCount);
+			void marshal_schedule(const int paramCount);
+			void marshal_emit(const int paramCount);
+			void marshal_log(const int paramCount);
+			void marshal_break(const int paramCount);
+			void marshal_dt_within(const int paramCount, const int64_t rowStamp);
+			void marshal_dt_between(const int paramCount, const int64_t rowStamp);
+			void marshal_bucket(const int paramCount);
+			void marshal_round(const int paramCount);
+			void marshal_fix(const int paramCount);
 
-			void marshal_makeDict(int paramCount);
-			void marshal_makeList(int paramCount);
-			void marshal_makeSet(int paramCount);
+			void marshal_makeDict(const int paramCount);
+			void marshal_makeList(const int paramCount);
+			void marshal_makeSet(const int paramCount);
 
-			void marshal_population(int paramCount);
-			void marshal_intersection(int paramCount);
-			void marshal_union(int paramCount);
-			void marshal_compliment(int paramCount);
-			void marshal_difference(int paramCount);
+			void marshal_population(const int paramCount);
+			void marshal_intersection(const int paramCount);
+			void marshal_union(const int paramCount);
+			void marshal_compliment(const int paramCount);
+			void marshal_difference(const int paramCount);
+
+			void marshal_slice(const int paramCount);
+			void marshal_find(const int paramCount);
 
 			// get a string from the literals script block by ID
-			string getLiteral(int64_t id) const;
+			string getLiteral(const int64_t id) const;
 
-			bool marshal(instruction_s* inst, int& currentRow);
-			void opRunner(instruction_s* inst, int currentRow = 0);
+			bool marshal(Instruction_s* inst, int& currentRow);
+			void opRunner(Instruction_s* inst, int currentRow = 0);
 
 			void setScheduleCB(function<bool(int64_t functionHash, int seconds)> cb);
 			void setEmitCB(function<bool(string emitMessage)> cb);

--- a/src/queryinterpreter.h
+++ b/src/queryinterpreter.h
@@ -77,7 +77,7 @@ namespace openset
 			const int64_t breakTopHash = MakeHash("top");
 
 			// execution
-			Macro_S& macros;
+			Macro_s& macros;
 			cvar* stack;
 			cvar* stackPtr;
 
@@ -144,7 +144,7 @@ namespace openset
 			Debug_s* lastDebug{ nullptr };
 
 			explicit Interpreter(
-				Macro_S& macros,
+				Macro_s& macros,
 				const InterpretMode_e interpretMode = InterpretMode_e::query);
 
 			~Interpreter();
@@ -194,7 +194,7 @@ namespace openset
 			void marshal_split(const int paramCount) const;
 			void marshal_strip(const int paramCount) const;
 
-			void marshal_url_decode(const int paramCount);
+			void marshal_url_decode(const int paramCount) const;
 
 			// get a string from the literals script block by ID
 			string getLiteral(const int64_t id) const;
@@ -213,8 +213,8 @@ namespace openset
 			// check for firstrun, check for globals.
 			void execReset();
 			void exec();
-			void exec(string functionName);
-			void exec(int64_t functionHash);
+			void exec(const string functionName);
+			void exec(const int64_t functionHash);
 		};
 	}
 }

--- a/src/queryinterpreter.h
+++ b/src/queryinterpreter.h
@@ -167,7 +167,7 @@ namespace openset
 
 			SegmentList* getSegmentList() const;
 
-			void marshal_tally(const int paramCount, const col_s* columns, const int currentRow);
+			void marshal_tally(const int paramCount, const Col_s* columns, const int currentRow);
 
 			void marshal_schedule(const int paramCount);
 			void marshal_emit(const int paramCount);
@@ -190,7 +190,11 @@ namespace openset
 			void marshal_difference(const int paramCount);
 
 			void marshal_slice(const int paramCount);
-			void marshal_find(const int paramCount);
+			void marshal_find(const int paramCount, const bool reverse = false);
+			void marshal_split(const int paramCount) const;
+			void marshal_strip(const int paramCount) const;
+
+			void marshal_url_decode(const int paramCount);
 
 			// get a string from the literals script block by ID
 			string getLiteral(const int64_t id) const;

--- a/src/queryparser.cpp
+++ b/src/queryparser.cpp
@@ -11,12 +11,7 @@
 using namespace openset::query;
 
 QueryParser::QueryParser(const parseMode_e parseMode) :
-	blockCounter(1),
-	tableColumns(nullptr),
-	parseMode(parseMode),
-	templating(nullptr),
-	isSegmentMath(false),
-	useSessions(false)
+	parseMode(parseMode)
 {}
 
 QueryParser::~QueryParser()
@@ -2683,7 +2678,9 @@ void QueryParser::lineTranslation(FirstPass& lines) const
 				 */
 				if (basic_string<char>::size_type pos; 
 					(pos = conditions[index].find(".find")) != std::string::npos ||
+					(pos = conditions[index].find(".rfind")) != std::string::npos ||
 					(pos = conditions[index].find(".split")) != std::string::npos ||
+					(pos = conditions[index].find(".strip")) != std::string::npos ||
 					(pos = conditions[index].find(".append")) != std::string::npos ||
 					(pos = conditions[index].find(".pop")) != std::string::npos ||
 					(pos = conditions[index].find(".clear")) != std::string::npos ||
@@ -3888,6 +3885,13 @@ bool QueryParser::compileQuery(const char* query, Columns* columnsPtr, Macro_S& 
 			auto hintPair = HintPair(n, {});
 			evaluateHints(n, hintPair.second);
 			macros.indexes.emplace_back(hintPair);
+		}
+
+		if (useSessions)
+		{
+			macros.vars.tableVars.push_back({ "__session", "grid" });
+			macros.vars.tableVars.back().column = COL_SESSION;
+			macros.vars.tableVars.back().index = macros.vars.tableVars.size() - 1;
 		}
 
 		macros.segments = std::move(vars.segmentNames); // move these over, these are evaluated at run-time

--- a/src/queryparser.h
+++ b/src/queryparser.h
@@ -210,20 +210,20 @@ namespace openset
 
 			middleVariables_s vars;
 
-			int blockCounter;
+			int blockCounter{ 1 };
 
 			HintList hintNames;
 			HintMap hintMap;			
 
-			Columns* tableColumns;
+			Columns* tableColumns{ nullptr };
 
-			parseMode_e parseMode;
+			parseMode_e parseMode{ parseMode_e::query };
 
-			ParamVars* templating;
+			ParamVars* templating{ nullptr };
 
 			bool isSegment{ false };
-			bool isSegmentMath;
-			bool useSessions;
+			bool isSegmentMath{ false };
+			bool useSessions{ false };
 
 			bool useGlobals{ false };
 
@@ -233,7 +233,7 @@ namespace openset
 			mutable int autoCounter{ 0 };
 			bool segmentUseCached{ false };
 
-			explicit QueryParser(parseMode_e parseMode = parseMode_e::query);
+			explicit QueryParser(const parseMode_e parseMode = parseMode_e::query);
 			~QueryParser();
 
 			static bool isVar(VarMap& vars, const string name)

--- a/src/queryparser.h
+++ b/src/queryparser.h
@@ -132,7 +132,7 @@ namespace openset
 
 			struct MiddleOp_s
 			{
-				opCode_e op{opCode_e::NOP};
+				OpCode_e op{OpCode_e::NOP};
 				int64_t params{ 0 };
 				int64_t value{ 0 };
 				string valueString;
@@ -147,12 +147,12 @@ namespace openset
 				MiddleOp_s()
 				{}
 
-				MiddleOp_s(const opCode_e op, const int64_t value) :
+				MiddleOp_s(const OpCode_e op, const int64_t value) :
 					op(op),
 					value(value)
 				{}
 
-				MiddleOp_s(const opCode_e op, const int64_t value, Debug_s& debugCopy, const int64_t lambda = -1) :
+				MiddleOp_s(const OpCode_e op, const int64_t value, Debug_s& debugCopy, const int64_t lambda = -1) :
 					op(op),
 					value(value),
 					lambda(lambda)
@@ -162,7 +162,7 @@ namespace openset
 					debug.translation = debugCopy.translation;
 				}
 
-				MiddleOp_s(const opCode_e op, const string valueString, Debug_s& debugCopy, const int64_t lambda = -1) :
+				MiddleOp_s(const OpCode_e op, const string valueString, Debug_s& debugCopy, const int64_t lambda = -1) :
 					op(op),
 					valueString(valueString),
 					isString(true),
@@ -181,12 +181,12 @@ namespace openset
 				int64_t blockId;
 				int64_t refs; // block reference count
 				MiddleOpList code;
-				blockType_e type;
+				BlockType_e type;
 				string blockName; // function name in general
 				MiddleBlock_s() :
 					blockId(-1),
 					refs(0),
-					type(blockType_e::code)
+					type(BlockType_e::code)
 				{}
 			};
 
@@ -286,13 +286,13 @@ namespace openset
 				if (isColumnVar(name))
 				{
 					const auto var = vars.columnVars.find(name);
-					return (var->second.modifier != modifiers_e::var);
+					return (var->second.modifier != Modifiers_e::var);
 				}
 
 				if (isGroupVar(name))
 				{
 					const auto var = vars.groupVars.find(name);
-					return (var->second.modifier != modifiers_e::var);
+					return (var->second.modifier != Modifiers_e::var);
 				}
 
 				return false;
@@ -333,9 +333,9 @@ namespace openset
 			static LineParts breakLine(const string &text);
 
 			FirstPass mergeLines(FirstPass& lines) const;
-			FirstPass extractLines(const char* query) const;
+			FirstPass extractLines(const char* query);
 
-			void lineTranslation(FirstPass& lines) const;
+			void lineTranslation(FirstPass& lines);
 
 			// converts line list into blocks by indent level, sets
 			// references for sub-block in parent block
@@ -364,11 +364,11 @@ namespace openset
 		public:
 
 			// compile a query into a macro_s block
-			bool compileQuery(const char* query, Columns* columnsPtr, Macro_S& macros, ParamVars* templateVars = nullptr);
+			bool compileQuery(const char* query, Columns* columnsPtr, Macro_s& macros, ParamVars* templateVars = nullptr);
 
 			static std::vector<std::pair<std::string, std::string>> extractCountQueries(const char* query);
 		};
 
-		string MacroDbg(Macro_S& macro);
+		string MacroDbg(Macro_s& macro);
 	};
 };

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -87,7 +87,7 @@ void ResultSet::setAtDepth(RowKey& key, function<void(Accumulator*)> set_cb)
 */
 
 ResultSet::RowVector ResultMuxDemux::mergeResultSets(
-	const openset::query::macro_s macros,
+	const openset::query::Macro_S macros,
 	openset::db::Table* table,
 	std::vector<openset::result::ResultSet*> resultSets)
 {
@@ -170,9 +170,9 @@ ResultSet::RowVector ResultMuxDemux::mergeResultSets(
 						{
 							const auto valueIndex = columnIndex + shiftOffset;
 
-							if (right->columns[valueIndex].value != NULLCELL)
+							if (right->columns[valueIndex].value != NONE)
 							{
-								if (left->columns[valueIndex].value == NULLCELL)
+								if (left->columns[valueIndex].value == NONE)
 								{
 									// if it's the first setting, copy the whole dang thang.
 									left->columns[valueIndex] = right->columns[valueIndex];
@@ -235,7 +235,7 @@ ResultSet::RowVector ResultMuxDemux::mergeResultSets(
 }
 
 bigRing<int64_t, const char*> ResultMuxDemux::mergeText(
-	const openset::query::macro_s macros,
+	const openset::query::Macro_S macros,
 	openset::db::Table* table,
 	std::vector<openset::result::ResultSet*> resultSets)
 {
@@ -256,7 +256,7 @@ bigRing<int64_t, const char*> ResultMuxDemux::mergeText(
 }
 
 char* ResultMuxDemux::resultSetToInternode(
-	const openset::query::macro_s macros,
+	const openset::query::Macro_S macros,
 	openset::db::Table* table,
 	ResultSet::RowVector& rows,
 	bigRing<int64_t, const char*>& mergedText,
@@ -396,7 +396,7 @@ openset::result::ResultSet* ResultMuxDemux::internodeToResultSet(
 }
 
 void ResultMuxDemux::resultSetToJSON(
-	const openset::query::macro_s macros,
+	const openset::query::Macro_S macros,
 	openset::db::Table* table,
 	cjson* doc,
 	ResultSet::RowVector& rows,
@@ -420,7 +420,7 @@ void ResultMuxDemux::resultSetToJSON(
 
 		// if no column is found we can't look in the AttributeBlob, so
 		// return NA_TEXT
-		if (column == NULLCELL)
+		if (column == NONE)
 			return NA_TEXT;
 
 		// look in the blob
@@ -486,7 +486,7 @@ void ResultMuxDemux::resultSetToJSON(
 
 		// set group - this could be text... so, lets see if we cached it (all text 
 		// stored by script will be cached)
-		auto text = getText(NULLCELL, currentKey.key[depth]);
+		auto text = getText(NONE, currentKey.key[depth]);
 
 		if (text != NA_TEXT)
 			entry->set("g", text);
@@ -510,7 +510,7 @@ void ResultMuxDemux::resultSetToJSON(
 				// Is this a null, a double, a string or anything else (ints)
 
 				// sorry for all the {} but it makes it easier for me to follow
-				if (r.second->columns[dataIndex].value == NULLCELL)
+				if (r.second->columns[dataIndex].value == NONE)
 				{
 					array->pushNull();
 				}
@@ -547,7 +547,7 @@ void ResultMuxDemux::resultSetToJSON(
 						break;
 					case query::modifiers_e::var:
 					{
-						auto columnText = getText(NULLCELL, r.second->columns[dataIndex].value);
+						auto columnText = getText(NONE, r.second->columns[dataIndex].value);
 
 						// TODO - figure out some smart way to say this was a floating point number
 

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -49,7 +49,7 @@ void ResultSet::makeSortedList()
 		});
 }
 
-void ResultSet::setAtDepth(RowKey& key, function<void(Accumulator*)> set_cb)
+void ResultSet::setAtDepth(RowKey& key, const function<void(Accumulator*)> set_cb)
 {
 	auto tPair = results.get(key);
 
@@ -87,12 +87,10 @@ void ResultSet::setAtDepth(RowKey& key, function<void(Accumulator*)> set_cb)
 */
 
 ResultSet::RowVector ResultMuxDemux::mergeResultSets(
-	const openset::query::Macro_S macros,
+	const openset::query::Macro_s macros,
 	openset::db::Table* table,
 	std::vector<openset::result::ResultSet*> resultSets)
 {
-
-	auto schema = table->getColumns();
 
 	vector<ResultSet::RowVector*> mergeList;
 
@@ -182,29 +180,30 @@ ResultSet::RowVector ResultMuxDemux::mergeResultSets(
 									// we are updating columns here, accumulator rules apply here
 									switch (macros.vars.columnVars[columnIndex].modifier) // WAS TABLEVAR
 									{
-									case query::modifiers_e::min:
+									case query::Modifiers_e::min:
 										if (left->columns[valueIndex].value < right->columns[valueIndex].value)
 										{
 											left->columns[valueIndex].value = right->columns[valueIndex].value;
 											left->columns[valueIndex].count = right->columns[valueIndex].count;
 										}
 										break;
-									case query::modifiers_e::max:
+									case query::Modifiers_e::max:
 										if (left->columns[valueIndex].value > right->columns[valueIndex].value)
 										{
 											left->columns[valueIndex].value = right->columns[valueIndex].value;
 											left->columns[valueIndex].count = right->columns[valueIndex].count;
 										}
 										break;
-									case query::modifiers_e::value:
+									case query::Modifiers_e::value:
 
 										left->columns[valueIndex].value = right->columns[valueIndex].value;
 										left->columns[valueIndex].count = right->columns[valueIndex].count;
 										break;
-									case query::modifiers_e::var:
-									case query::modifiers_e::avg: // average is determined later
-									case query::modifiers_e::sum:
-									case query::modifiers_e::count:
+									case query::Modifiers_e::var:
+									case query::Modifiers_e::avg: // average is determined later
+									case query::Modifiers_e::sum:
+									case query::Modifiers_e::count:
+									case query::Modifiers_e::dist_count_person:
 										left->columns[valueIndex].value += right->columns[valueIndex].value;
 										left->columns[valueIndex].count += right->columns[valueIndex].count;
 										break;
@@ -235,7 +234,7 @@ ResultSet::RowVector ResultMuxDemux::mergeResultSets(
 }
 
 bigRing<int64_t, const char*> ResultMuxDemux::mergeText(
-	const openset::query::Macro_S macros,
+	const openset::query::Macro_s macros,
 	openset::db::Table* table,
 	std::vector<openset::result::ResultSet*> resultSets)
 {
@@ -249,20 +248,19 @@ bigRing<int64_t, const char*> ResultMuxDemux::mergeText(
 
 	// merge all the localText mappings into a merged text mapping
 	for (auto &r : resultSets)
-		for (auto t : r->localText)
+		for (const auto &t : r->localText)
 			mergedText[t.first] = t.second;
 
 	return mergedText;
 }
 
 char* ResultMuxDemux::resultSetToInternode(
-	const openset::query::Macro_S macros,
+	const openset::query::Macro_s macros,
 	openset::db::Table* table,
 	ResultSet::RowVector& rows,
 	bigRing<int64_t, const char*>& mergedText,
 	int64_t& bufferLength)
 {
-	char* result = nullptr;
 	bufferLength = 0;
 
 	// we are going to serialize to a HeapStack object
@@ -328,7 +326,7 @@ char* ResultMuxDemux::resultSetToInternode(
 
 bool ResultMuxDemux::isInternode(
 	char* data,
-	int64_t blockLength)
+	const int64_t blockLength)
 {
 	const auto binaryMarkerPtr = static_cast<char*>(data);
 
@@ -338,8 +336,8 @@ bool ResultMuxDemux::isInternode(
 }
 
 openset::result::ResultSet* ResultMuxDemux::internodeToResultSet(
-	char* data, 
-	int64_t blockLength)
+	char* data,
+	const int64_t blockLength)
 {
 	// we are going to make a sorta-bogus result object.
 	// the actual 
@@ -396,13 +394,12 @@ openset::result::ResultSet* ResultMuxDemux::internodeToResultSet(
 }
 
 void ResultMuxDemux::resultSetToJSON(
-	const openset::query::Macro_S macros,
+	const openset::query::Macro_s macros,
 	openset::db::Table* table,
 	cjson* doc,
 	ResultSet::RowVector& rows,
 	bigRing<int64_t, const char*>& mergedText)
 {
-
 	auto blob = table->getAttributeBlob();
 
 	const auto shiftIterations = macros.segments.size() ? macros.segments.size() : 1;
@@ -439,15 +436,12 @@ void ResultMuxDemux::resultSetToJSON(
 		return NA_TEXT;
 	};
 
-	auto tableColumns = table->getColumns();
-
 	RowKey lastKey;
 	lastKey.clear();
 
 	// we are going to move the root down a node
 	auto current = doc->pushArray();
 	current->setName("_");
-	auto root = current;
 
 	auto maxDepth = 0;
 	for (auto &r : rows)
@@ -518,15 +512,15 @@ void ResultMuxDemux::resultSetToJSON(
 				{
 					switch (g.modifier)
 					{
-					case query::modifiers_e::sum:
-					case query::modifiers_e::min:
-					case query::modifiers_e::max:
+					case query::Modifiers_e::sum:
+					case query::Modifiers_e::min:
+					case query::Modifiers_e::max:
 						if (g.schemaType == db::columnTypes_e::doubleColumn)
 							array->push(r.second->columns[dataIndex].value / 10000.0);
 						else
 							array->push(r.second->columns[dataIndex].value);
 						break;
-					case query::modifiers_e::avg:
+					case query::Modifiers_e::avg:
 						if (!r.second->columns[dataIndex].count)
 							array->pushNull();
 						else if (g.schemaType == db::columnTypes_e::doubleColumn)
@@ -534,10 +528,11 @@ void ResultMuxDemux::resultSetToJSON(
 						else
 							array->push(r.second->columns[dataIndex].value / static_cast<double>(r.second->columns[dataIndex].count));
 						break;
-					case query::modifiers_e::count:
+					case query::Modifiers_e::count:
+					case query::Modifiers_e::dist_count_person:
 						array->push(r.second->columns[dataIndex].value);
 						break;
-					case query::modifiers_e::value:
+					case query::Modifiers_e::value:
 						if (g.schemaType == db::columnTypes_e::textColumn)
 							array->push(getText(g.schemaColumn, r.second->columns[dataIndex].value));
 						else if (g.schemaType == db::columnTypes_e::doubleColumn)
@@ -545,7 +540,7 @@ void ResultMuxDemux::resultSetToJSON(
 						else
 							array->push(r.second->columns[dataIndex].value);
 						break;
-					case query::modifiers_e::var:
+					case query::Modifiers_e::var:
 					{
 						auto columnText = getText(NONE, r.second->columns[dataIndex].value);
 

--- a/src/result.h
+++ b/src/result.h
@@ -27,20 +27,20 @@ namespace openset
 
 			inline void clear()
 			{
-				key[0] = NULLCELL;
-				key[1] = NULLCELL;
-				key[2] = NULLCELL;
-				key[3] = NULLCELL;
-				key[4] = NULLCELL;
-				key[5] = NULLCELL;
-				key[6] = NULLCELL;
-				key[7] = NULLCELL;
+				key[0] = NONE;
+				key[1] = NONE;
+				key[2] = NONE;
+				key[3] = NONE;
+				key[4] = NONE;
+				key[5] = NONE;
+				key[6] = NONE;
+				key[7] = NONE;
 			}
 
 			inline void clearFrom(int index)
 			{
 				for (auto iter = key + index; iter < key + keyDepth; ++iter)
-					*iter = NULLCELL;
+					*iter = NONE;
 			}
 
 			inline RowKey keyFrom(int index) const
@@ -60,7 +60,7 @@ namespace openset
 			{
 				auto count = 0;
 				for (auto iter = key; iter < key + keyDepth; ++iter, ++count)
-					if (*iter == NULLCELL)
+					if (*iter == NONE)
 						break;
 				return count;
 			}
@@ -116,7 +116,7 @@ namespace std
 			auto count = 1;
 			for (auto iter = key.key + 1; iter < key.key + openset::result::keyDepth; ++iter, ++count)
 			{
-				if (*iter == NULLCELL)
+				if (*iter == NONE)
 					return hash;
 				hash = (hash << count) + key.key[1];
 			}
@@ -151,8 +151,8 @@ namespace openset
 			{
 				for (auto &i : columns)
 				{
-					//i.distinctId = NULLCELL;
-					i.value = NULLCELL;
+					//i.distinctId = NONE;
+					i.value = NONE;
 					i.count = 0;
 				}
 			}
@@ -320,18 +320,18 @@ namespace openset
 			// retuns a new result set which can be used to serialize to
 			// JSON
 			static bigRing<int64_t, const char*> mergeText(
-				const openset::query::macro_s macros,
+				const openset::query::Macro_S macros,
 				openset::db::Table* table,
 				std::vector<openset::result::ResultSet*> resultSets);
 
 			static ResultSet::RowVector mergeResultSets(
-				const openset::query::macro_s macros,
+				const openset::query::Macro_S macros,
 				openset::db::Table* table,
 				std::vector<openset::result::ResultSet*> resultSets);
 
 			// generate a result set from JSON
 			static char* resultSetToInternode(
-				const openset::query::macro_s macros,
+				const openset::query::Macro_S macros,
 				openset::db::Table* table,
 				ResultSet::RowVector& rows,
 				bigRing<int64_t, const char*>& mergedText,
@@ -344,7 +344,7 @@ namespace openset
 				int64_t blockLength);
 
 			static void resultSetToJSON(
-				const openset::query::macro_s macros,
+				const openset::query::Macro_S macros,
 				openset::db::Table* table,
 				cjson* doc,
 				ResultSet::RowVector& rows,

--- a/src/result.h
+++ b/src/result.h
@@ -37,20 +37,20 @@ namespace openset
 				key[7] = NONE;
 			}
 
-			inline void clearFrom(int index)
+			inline void clearFrom(const int index)
 			{
 				for (auto iter = key + index; iter < key + keyDepth; ++iter)
 					*iter = NONE;
 			}
 
-			inline RowKey keyFrom(int index) const
+			inline RowKey keyFrom(const int index) const
 			{
 				auto newKey{ *this };
 				newKey.clearFrom(index);
 				return newKey;
 			}
 
-			inline void keyFrom(int index, RowKey& rowKey) const
+			inline void keyFrom(const int index, RowKey& rowKey) const
 			{
 				rowKey = *this;
 				rowKey.clearFrom(index);
@@ -130,7 +130,7 @@ namespace openset
 {
 	namespace result
 	{
-		struct accumulation_s
+		struct Accumulation_s
 		{
 			int64_t value;
 			int32_t count;
@@ -140,7 +140,7 @@ namespace openset
 
 		struct Accumulator
 		{
-			accumulation_s columns[ACCUMULATOR_DEPTH];
+			Accumulation_s columns[ACCUMULATOR_DEPTH];
 
 			Accumulator()
 			{
@@ -182,11 +182,11 @@ namespace openset
 			ResultSet(ResultSet&& other) noexcept;
 
 			void makeSortedList();
-			void setAtDepth(RowKey& key, function<void(Accumulator*)> set_cb);
+			void setAtDepth(RowKey& key, const function<void(Accumulator*)> set_cb);
 
 			// this is a cache of text values local to our partition (thread), blob requires
 			// a lock, whereas this does not, we will merge them after.
-			void addLocalText(int64_t hashId, cvar &value)
+			void addLocalText(const int64_t hashId, cvar &value)
 			{
 				const auto textPair = localText.get(hashId);
 
@@ -198,7 +198,7 @@ namespace openset
 				}
 			}
 
-			void addLocalText(int64_t hashId, const std::string &value)
+			void addLocalText(const int64_t hashId, const std::string &value)
 			{
 				const auto textPair = localText.get(hashId);
 
@@ -210,7 +210,7 @@ namespace openset
 				}
 			}
 
-			void addLocalText(int64_t hashId, char* value, int32_t length)
+			void addLocalText(const int64_t hashId, char* value, const int32_t length)
 			{
 				const auto textPair = localText.get(hashId);
 
@@ -248,15 +248,13 @@ namespace openset
 			{}
 
 			CellQueryResult_s(
-				//OpenSet::result::ResultSet* partitionResult,
-				int64_t executionTime,
-				int64_t runCount,
-				int64_t population,
-				int64_t totalPopulation,
-				int64_t instanceId,
-				openset::errors::Error error,
+				const int64_t executionTime,
+				const int64_t runCount,
+				const int64_t population,
+				const int64_t totalPopulation,
+				const int64_t instanceId,
+				const openset::errors::Error error,
 				openset::db::TablePartitioned* partitionedObjects) :
-					//result(partitionResult),
 					time(executionTime),
 					iterations(runCount),
 					population(population),
@@ -277,17 +275,11 @@ namespace openset
 				parts = other.parts;
 				other.parts = nullptr;
 
-				//result = other.result;
-				//other.result = nullptr;
-
 				time = other.time;
 			}
 
 			~CellQueryResult_s()
-			{
-				//if (result)
-					//delete result;
-			}
+			{}
 
 			CellQueryResult_s& operator=(CellQueryResult_s&& other) noexcept
 			{
@@ -300,9 +292,6 @@ namespace openset
 
 				parts = other.parts;
 				other.parts = nullptr;
-
-				//result = other.result;
-				//other.result = nullptr;
 
 				return *this;
 			}
@@ -320,18 +309,18 @@ namespace openset
 			// retuns a new result set which can be used to serialize to
 			// JSON
 			static bigRing<int64_t, const char*> mergeText(
-				const openset::query::Macro_S macros,
+				const openset::query::Macro_s macros,
 				openset::db::Table* table,
 				std::vector<openset::result::ResultSet*> resultSets);
 
 			static ResultSet::RowVector mergeResultSets(
-				const openset::query::Macro_S macros,
+				const openset::query::Macro_s macros,
 				openset::db::Table* table,
 				std::vector<openset::result::ResultSet*> resultSets);
 
 			// generate a result set from JSON
 			static char* resultSetToInternode(
-				const openset::query::Macro_S macros,
+				const openset::query::Macro_s macros,
 				openset::db::Table* table,
 				ResultSet::RowVector& rows,
 				bigRing<int64_t, const char*>& mergedText,
@@ -344,7 +333,7 @@ namespace openset
 				int64_t blockLength);
 
 			static void resultSetToJSON(
-				const openset::query::Macro_S macros,
+				const openset::query::Macro_s macros,
 				openset::db::Table* table,
 				cjson* doc,
 				ResultSet::RowVector& rows,

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -881,11 +881,13 @@ void Admin::createTable(Database* database, AsyncPool* partitions, cjson* reques
 	auto columns = table->getColumns();
 
 	// set the default required columns
-	columns->setColumn(COL_STAMP, "__stamp", columnTypes_e::intColumn, false, 0);
-	columns->setColumn(COL_ACTION, "__action", columnTypes_e::textColumn, false, 0);
-	columns->setColumn(COL_UUID, "__uuid", columnTypes_e::intColumn, false, 0);
-	columns->setColumn(COL_TRIGGERS, "__triggers", columnTypes_e::textColumn, false, 0);
-	columns->setColumn(COL_EMIT, "__emit", columnTypes_e::textColumn, false, 0);
+	columns->setColumn(COL_STAMP, "__stamp", columnTypes_e::intColumn, false);
+	columns->setColumn(COL_ACTION, "__action", columnTypes_e::textColumn, false);
+	columns->setColumn(COL_UUID, "__uuid", columnTypes_e::intColumn, false);
+	columns->setColumn(COL_TRIGGERS, "__triggers", columnTypes_e::textColumn, false);
+	columns->setColumn(COL_EMIT, "__emit", columnTypes_e::textColumn, false);
+	columns->setColumn(COL_SEGMENT, "__segment", columnTypes_e::textColumn, false);
+	columns->setColumn(COL_SESSION, "__session", columnTypes_e::intColumn, false);
 
 	int64_t columnEnum = 1000;
 

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1745,7 +1745,7 @@ void forkQuery(
 	Table* table,
 	AsyncPool* partitions,
 	cjson* request,
-	openset::query::macro_s queryMacros,
+	openset::query::Macro_S queryMacros,
 	openset::comms::Message* message) // errorHandled will be true if an error was happend during the fork
 {
 
@@ -1967,7 +1967,7 @@ void Query::onQuery(
 			{
 				case cjsonType::VOIDED: 
 				case cjsonType::NUL:
-					paramVar = NULLCELL;
+					paramVar = NONE;
 				break;
 				case cjsonType::OBJECT: 
 				case cjsonType::ARRAY: 
@@ -1990,7 +1990,7 @@ void Query::onQuery(
 		}
 	}
 
-	openset::query::macro_s queryMacros; // this is our compiled code block
+	openset::query::Macro_S queryMacros; // this is our compiled code block
 	openset::query::QueryParser p;
 
 	try
@@ -2254,7 +2254,7 @@ void Query::onCount(
 			{
 			case cjsonType::VOIDED:
 			case cjsonType::NUL:
-				paramVar = NULLCELL;
+				paramVar = NONE;
 				break;
 			case cjsonType::OBJECT:
 			case cjsonType::ARRAY:
@@ -2286,7 +2286,7 @@ void Query::onCount(
 	for (auto r: subQueries)
 	{
 
-		openset::query::macro_s queryMacros; // this is our compiled code block
+		openset::query::Macro_S queryMacros; // this is our compiled code block
 		openset::query::QueryParser p;
 		p.compileQuery(r.second.c_str(), table->getColumns(), queryMacros, &paramVars);
 
@@ -2306,7 +2306,7 @@ void Query::onCount(
 
 		queryMacros.isSegment = true;
 
-		queries.emplace_back(std::pair<std::string, openset::query::macro_s>{r.first, queryMacros});
+		queries.emplace_back(std::pair<std::string, openset::query::Macro_S>{r.first, queryMacros});
 	}
 
 	// Shared Results - Partitions spread across working threads (AsyncLoop's made by AsyncPool)

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -211,7 +211,7 @@ void Internode::transfer(Database* database, AsyncPool* partitions, cjson* reque
 
 	{ // get a list of tables
 		csLock lock(database->cs);
-		for (auto t : database->tables)
+		for (const auto t : database->tables)
 			tables.push_back(t.second);
 	}
 	
@@ -225,8 +225,8 @@ void Internode::transfer(Database* database, AsyncPool* partitions, cjson* reque
 
 		if (part)
 		{
-			char* blockPtr = nullptr;
-			int64_t blockSize = 0;
+			char* blockPtr;
+			int64_t blockSize;
 
 			{
 				HeapStack mem;
@@ -239,11 +239,11 @@ void Internode::transfer(Database* database, AsyncPool* partitions, cjson* reque
 				*(recast<int32_t*>(mem.newPtr(sizeof(int32_t)))) = partitionId;
 
 				// grab 4 bytes and set it the length of the table name
-				auto tableNameLength = recast<int32_t*>(mem.newPtr(sizeof(int32_t)));
+				const auto tableNameLength = recast<int32_t*>(mem.newPtr(sizeof(int32_t)));
 				*tableNameLength = t->getName().length() + 1;
 
 				// grab some bytes for the table name, and copy in the table name
-				auto name = mem.newPtr(*tableNameLength);
+				const auto name = mem.newPtr(*tableNameLength);
 				strcpy(name, t->getName().c_str());
 
 				// serialize the attributes
@@ -256,7 +256,7 @@ void Internode::transfer(Database* database, AsyncPool* partitions, cjson* reque
 				blockSize = mem.getBytes();
 			}
 
-			auto responseMessage = openset::globals::mapper->dispatchSync(
+			const auto responseMessage = openset::globals::mapper->dispatchSync(
 				targetNode,
 				openset::mapping::rpc_e::inter_node_partition_xfer,
 				blockPtr,
@@ -372,25 +372,25 @@ void Admin::error(openset::errors::Error error, cjson* response)
 	cjson::Parse(error.getErrorJSON(), response);
 }
 
-enum class forwardStatus_e : int
+enum class ForwardStatus_e : int
 {
 	dispatched,
 	isForwarded,
 	error
 };
 
-forwardStatus_e forwardRequest(
-	openset::mapping::rpc_e rpc,
+ForwardStatus_e forwardRequest(
+	const openset::mapping::rpc_e rpc,
 	Database* database,
 	AsyncPool* partitions,
 	cjson* request,
 	cjson* response)
 {
 	if (!openset::globals::mapper->routes.size())
-		return forwardStatus_e::error;
+		return ForwardStatus_e::error;
 	
 	if (request->xPathBool("/forwarded", false))
-		return forwardStatus_e::isForwarded;
+		return ForwardStatus_e::isForwarded;
 
 	request->set("forwarded", true);
 
@@ -412,13 +412,12 @@ forwardStatus_e forwardRequest(
 
 	openset::globals::mapper->releaseResponses(result);
 
-	return (inError) ? forwardStatus_e::error : forwardStatus_e::dispatched;
+	return (inError) ? ForwardStatus_e::error : ForwardStatus_e::dispatched;
 }
 
 void Admin::onMessage(
 	Database* database,
 	AsyncPool* partitions,
-	//uvConnection* connection,
 	openset::comms::Message* message)
 {
 	auto msgText = message->toString();
@@ -467,7 +466,7 @@ void Admin::onMessage(
 		handled = true;
 		if (!openset::globals::sentinel->isSentinel())
 		{
-			auto sentinelRoute = openset::globals::sentinel->getSentinel();
+			const auto sentinelRoute = openset::globals::sentinel->getSentinel();
 
 			Logger::get().info("forwarding invite to sentinal '" + openset::globals::mapper->getRouteName(sentinelRoute) + "'");
 
@@ -492,6 +491,7 @@ void Admin::onMessage(
 			inviteNode(database, partitions, &request, &response);
 		}
 		break;
+		default: ;
 	};
 
 	if (handled)
@@ -507,7 +507,7 @@ void Admin::onMessage(
 		&request,
 		&response))
 	{
-	case forwardStatus_e::error:
+	case ForwardStatus_e::error:
 		error(
 			openset::errors::Error{
 			openset::errors::errorClass_e::config,
@@ -516,7 +516,7 @@ void Admin::onMessage(
 			&response);
 		break;
 
-	case forwardStatus_e::isForwarded:
+	case ForwardStatus_e::isForwarded:
 		switch (iter->second) // second is type adminFunction_e 
 		{
 		case adminFunction_e::create_table:
@@ -551,7 +551,7 @@ void Admin::onMessage(
 			// error
 			break;
 		}
-		case forwardStatus_e::dispatched: break;
+		case ForwardStatus_e::dispatched: break;
 		default: ;
 	};
 
@@ -612,7 +612,7 @@ void Admin::initCluster(
 
 	partitions->mapPartitionsToAsyncWorkers();
 
-	auto logLine = "configured for " + to_string(partitionMax) + " partitions.";
+	const auto logLine = "configured for " + to_string(partitionMax) + " partitions.";
 	Logger::get().info(logLine);
 	response->set("message", logLine);	
 
@@ -637,10 +637,10 @@ void Admin::inviteNode(Database* database, AsyncPool* partitions, cjson* request
 		return;
 	}
 
-	auto host = request->xPathString("/params/host", "");
-	auto port = request->xPathInt("/params/port", 0);
-	auto newNodeName = openset::config::createName();
-	auto newNodeId = MakeHash(newNodeName);
+	const auto host = request->xPathString("/params/host", "");
+	const auto port = request->xPathInt("/params/port", 0);
+	const auto newNodeName = openset::config::createName();
+	const auto newNodeId = MakeHash(newNodeName);
 
 	if (!host.length() || !port)
 	{
@@ -908,7 +908,7 @@ void Admin::createTable(Database* database, AsyncPool* partitions, cjson* reques
 			return;
 		}
 
-		auto colType = openset::db::columnTypes_e::intColumn;
+		columnTypes_e colType;
 
 		if (type == "text")
 			colType = columnTypes_e::textColumn;
@@ -959,13 +959,7 @@ void Admin::createTable(Database* database, AsyncPool* partitions, cjson* reques
 		}
 	}
 
-// make the output directory
-	//OpenSet::IO::Directory::mkdir(globals::running->path + "tables/" + tableName);
-
-	// write our new file
-	//cjson::toFile(globals::running->path + "tables/" + tableName + "/table.json", &tableJson, true);
-
-	auto logLine = "table '" + tableName + "' created.";
+	const auto logLine = "table '" + tableName + "' created.";
 	Logger::get().info(logLine);
 	response->set("message", logLine);
 
@@ -1041,7 +1035,7 @@ void Admin::describeTable(
 				columnRecord->set("deleted", c.deleted);
 		}
 
-	auto logLine = "describe table '" + tableName + "'.";
+	const auto logLine = "describe table '" + tableName + "'.";
 	Logger::get().info(logLine);
 	response->set("message", logLine);
 }
@@ -1301,11 +1295,7 @@ void Admin::setTrigger(Database* database, AsyncPool* partitions, cjson* request
 		}
 	}
 
-	// save out the config
-	// change - save is performed on commit
-	// table->saveConfig();
-
-	auto logLine = "set trigger '" + triggerName + "' on table '" + tableName + "'.";
+	const auto logLine = "set trigger '" + triggerName + "' on table '" + tableName + "'.";
 	Logger::get().info(logLine);
 	response->set("message", logLine);
 
@@ -1342,7 +1332,7 @@ void Admin::describeTriggers(Database* database, AsyncPool* partitions, cjson* r
 		return;
 	}
 
-	auto triggers = table->getTriggerConf();
+	const auto triggers = table->getTriggerConf();
 
 	auto triggerNode = response->setArray("triggers");
 
@@ -1353,7 +1343,7 @@ void Admin::describeTriggers(Database* database, AsyncPool* partitions, cjson* r
 		trigNode->set("entry", t.second->entryFunction);
 	}
 
-	auto logLine = "describe triggers on table '" + tableName + "'.";
+	const auto logLine = "describe triggers on table '" + tableName + "'.";
 	Logger::get().info(logLine);
 	response->set("message", logLine);
 }
@@ -1389,8 +1379,8 @@ void Admin::dropTrigger(Database* database, AsyncPool* partitions, cjson* reques
 		return;
 	}
 
-	auto triggers = table->getTriggerConf();
-	auto trigger = triggers->find(triggerName);
+	const auto triggers = table->getTriggerConf();
+	const auto trigger = triggers->find(triggerName);
 
 	if (trigger == triggers->end())
 	{
@@ -1406,7 +1396,7 @@ void Admin::dropTrigger(Database* database, AsyncPool* partitions, cjson* reques
 	triggers->erase(triggerName);
 	table->forceReload();
 
-	auto logLine = "dropped trigger '" + triggerName + "' on table '" + tableName + "'.";
+	const auto logLine = "dropped trigger '" + triggerName + "' on table '" + tableName + "'.";
 	Logger::get().info(logLine);
 	response->set("message", logLine);
 }
@@ -1414,7 +1404,6 @@ void Admin::dropTrigger(Database* database, AsyncPool* partitions, cjson* reques
 void Insert::onInsert(
 	Database* database,
 	AsyncPool* partitions,
-	//uvConnection* connection,
 	openset::comms::Message* message)
 {
 	auto msgText = message->toString();
@@ -1516,7 +1505,6 @@ void Insert::onInsert(
 	}
 
 	auto remoteCount = 0;
-	auto thanksCount = 0;
 
 	const auto thankyouCB = [](openset::comms::Message* message)
 	{		
@@ -1747,7 +1735,7 @@ void forkQuery(
 	Table* table,
 	AsyncPool* partitions,
 	cjson* request,
-	openset::query::Macro_S queryMacros,
+	openset::query::Macro_s queryMacros,
 	openset::comms::Message* message) // errorHandled will be true if an error was happend during the fork
 {
 
@@ -1808,7 +1796,7 @@ void forkQuery(
 		{
 			auto tNode = jsonArray->pushObject();
 
-			if (c.modifier == openset::query::modifiers_e::var)
+			if (c.modifier == openset::query::Modifiers_e::var)
 			{
 				tNode->set("mode", "var");
 				tNode->set("name", c.alias);
@@ -1836,7 +1824,7 @@ void forkQuery(
 			}
 			else if (openset::query::isTimeModifiers.count(c.modifier))
 			{
-				auto mode = openset::query::modifierDebugStrings.at(c.modifier);
+				auto mode = openset::query::ModifierDebugStrings.at(c.modifier);
 				toLower(mode);
 				tNode->set("mode", mode);
 				tNode->set("name", c.alias);
@@ -1844,7 +1832,7 @@ void forkQuery(
 			}
 			else
 			{
-				auto mode = openset::query::modifierDebugStrings.at(c.modifier);
+				auto mode = openset::query::ModifierDebugStrings.at(c.modifier);
 				toLower(mode);
 				tNode->set("mode", mode);
 				tNode->set("name", c.alias);
@@ -1913,12 +1901,11 @@ void Query::error(openset::errors::Error error, cjson* response)
 void Query::onQuery(
 	Database* database,
 	AsyncPool* partitions,
-	bool isFork,
+	const bool isFork,
 	cjson* request,
 	openset::comms::Message* message)
 {
-
-	std::string log = "Inbound query (fork: "s + (isFork ? "true"s : "false"s) + ")"s;
+	const std::string log = "Inbound query (fork: "s + (isFork ? "true"s : "false"s) + ")"s;
 	Logger::get().info(log);
 
 	const auto tableName = request->xPathString("/params/table", "");
@@ -1947,6 +1934,8 @@ void Query::onQuery(
 		message->reply("{\"error\":\"table '" + tableName +	"' could not be found\"}");
 		return;
 	}
+
+	const auto sessionTime = request->xPathInt("/params/session_time", table->getSessionTime());
 
 	/*
 	 * Build a map of variable names and vars that will
@@ -1992,7 +1981,7 @@ void Query::onQuery(
 		}
 	}
 
-	openset::query::Macro_S queryMacros; // this is our compiled code block
+	openset::query::Macro_s queryMacros; // this is our compiled code block
 	openset::query::QueryParser p;
 
 	try
@@ -2025,6 +2014,10 @@ void Query::onQuery(
 		message->reply(cjson::Stringify(&response, true));
 		return;
 	}
+
+	// set the sessionTime (timeout) value, this will get relayed 
+	// through the to oloop_query, the person object and finally the grid
+	queryMacros.sessionTime = sessionTime;
 
 	const auto compileTime = Now() - startTime;
 	const auto queryStart = Now();
@@ -2135,9 +2128,6 @@ void Query::onQuery(
 				voidfunc release_cb)
 		{ // process the data and respond
 
-			auto queryTime = Now() - queryStart;
-			auto serialStart = Now();
-
 			int64_t population = 0;
 			int64_t totalPopulation = 0;
 
@@ -2201,7 +2191,7 @@ void Query::onQuery(
 void Query::onCount(
 	Database* database,
 	AsyncPool* partitions,
-	bool isFork,
+	const bool isFork,
 	cjson* request,
 	openset::comms::Message* message)
 {
@@ -2288,7 +2278,7 @@ void Query::onCount(
 	for (auto r: subQueries)
 	{
 
-		openset::query::Macro_S queryMacros; // this is our compiled code block
+		openset::query::Macro_s queryMacros; // this is our compiled code block
 		openset::query::QueryParser p;
 		p.compileQuery(r.second.c_str(), table->getColumns(), queryMacros, &paramVars);
 
@@ -2308,7 +2298,7 @@ void Query::onCount(
 
 		queryMacros.isSegment = true;
 
-		queries.emplace_back(std::pair<std::string, openset::query::Macro_S>{r.first, queryMacros});
+		queries.emplace_back(std::pair<std::string, openset::query::Macro_s>{r.first, queryMacros});
 	}
 
 	// Shared Results - Partitions spread across working threads (AsyncLoop's made by AsyncPool)
@@ -2402,9 +2392,6 @@ void Query::onCount(
 			 voidfunc release_cb)
 		{ 
 			// process the data and respond
-			auto queryTime = Now() - queryStart;
-			auto serialStart = Now();
-
 			int64_t population = 0;
 			int64_t totalPopulation = 0;
 
@@ -2462,8 +2449,7 @@ void Query::onCount(
 	// pass factory function (as lambda) to create new cell objects
 	partitions->cellFactory(activeList, [shuttle, table, queries, resultSets, &workers, &instance](AsyncLoop* loop) -> OpenLoop*
 	{
-		instance++;
-		auto partitionId = loop->partition;
+		++instance;
 		++workers;
 		return new OpenLoopCount(shuttle, table, queries, resultSets[loop->getWorkerId()], instance);
 	});

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "common.h"
 #include "shuttle.h"
 #include "asyncpool.h"
 #include "database.h"
@@ -170,23 +169,25 @@ namespace openset
 			static void onQuery(
 				Database* database,
 				AsyncPool* partitions, 
-				bool isFork,
+				const bool isFork,
 				cjson* request,
 				comms::Message* message);
 
 			static void onCount(
 				Database* database,
 				AsyncPool* partitions,
-				bool isFork,
+				const bool isFork,
 				cjson* request,
 				comms::Message* message);
 
+			/*			
 			static void onPerson(
 				Database* database,
 				AsyncPool* partitions,
-				bool isFork,
+				const bool isFork,
 				cjson* request,
 				comms::Message* message);
+			*/
 		};
 
 		class Insert

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -26,11 +26,13 @@ Table::Table(string name, Database* database):
 	//loadConfig();
 
 	// set the default required columns
-	columns.setColumn(COL_STAMP, "__stamp", columnTypes_e::intColumn, false, 0);
-	columns.setColumn(COL_ACTION, "__action", columnTypes_e::textColumn, false, 0);
-	columns.setColumn(COL_UUID, "__uuid", columnTypes_e::intColumn, false, 0);
-	columns.setColumn(COL_TRIGGERS, "__triggers", columnTypes_e::textColumn, false, 0);
-	columns.setColumn(COL_EMIT, "__emit", columnTypes_e::textColumn, false, 0);
+	columns.setColumn(COL_STAMP, "__stamp", columnTypes_e::intColumn, false);
+	columns.setColumn(COL_ACTION, "__action", columnTypes_e::textColumn, false);
+	columns.setColumn(COL_UUID, "__uuid", columnTypes_e::intColumn, false);
+	columns.setColumn(COL_TRIGGERS, "__triggers", columnTypes_e::textColumn, false);
+	columns.setColumn(COL_EMIT, "__emit", columnTypes_e::textColumn, false);
+	columns.setColumn(COL_SEGMENT, "__segment", columnTypes_e::textColumn, false);
+	columns.setColumn(COL_SESSION, "__session", columnTypes_e::intColumn, false);
 
 	createMissingPartitionObjects();
 }
@@ -200,11 +202,13 @@ void Table::deserializeTable(cjson* doc)
 	}
 
 	// set the default required columns
-	columns.setColumn(COL_STAMP, "__stamp", columnTypes_e::intColumn, false, 0);
-	columns.setColumn(COL_ACTION, "__action", columnTypes_e::textColumn, false, 0);
-	columns.setColumn(COL_UUID, "__uuid", columnTypes_e::intColumn, false, 0);
-	columns.setColumn(COL_TRIGGERS, "__triggers", columnTypes_e::textColumn, false, 0);
-	columns.setColumn(COL_EMIT, "__emit", columnTypes_e::textColumn, false, 0);
+	columns.setColumn(COL_STAMP, "__stamp", columnTypes_e::intColumn, false);
+	columns.setColumn(COL_ACTION, "__action", columnTypes_e::textColumn, false);
+	columns.setColumn(COL_UUID, "__uuid", columnTypes_e::intColumn, false);
+	columns.setColumn(COL_TRIGGERS, "__triggers", columnTypes_e::textColumn, false);
+	columns.setColumn(COL_EMIT, "__emit", columnTypes_e::textColumn, false);
+	columns.setColumn(COL_SEGMENT, "__segment", columnTypes_e::textColumn, false);
+	columns.setColumn(COL_SESSION, "__session", columnTypes_e::intColumn, false);
 
 	// load the columns
 	auto columnNode = doc->xPath("/columns");
@@ -254,11 +258,13 @@ void Table::loadConfig()
 	if (globals::running->testMode)
 	{
 		// set default columns for test mode
-		columns.setColumn(COL_STAMP, "__stamp", columnTypes_e::intColumn, false, 0);
-		columns.setColumn(COL_ACTION, "__action", columnTypes_e::textColumn, false, 0);
-		columns.setColumn(COL_UUID, "__uuid", columnTypes_e::intColumn, false, 0);
-		columns.setColumn(COL_TRIGGERS, "__triggers", columnTypes_e::textColumn, false, 0);
-		columns.setColumn(COL_EMIT, "__emit", columnTypes_e::textColumn, false, 0);
+		columns.setColumn(COL_STAMP, "__stamp", columnTypes_e::intColumn, false);
+		columns.setColumn(COL_ACTION, "__action", columnTypes_e::textColumn, false);
+		columns.setColumn(COL_UUID, "__uuid", columnTypes_e::intColumn, false);
+		columns.setColumn(COL_TRIGGERS, "__triggers", columnTypes_e::textColumn, false);
+		columns.setColumn(COL_EMIT, "__emit", columnTypes_e::textColumn, false);
+		columns.setColumn(COL_SEGMENT, "__segment", columnTypes_e::textColumn, false);
+		columns.setColumn(COL_SESSION, "__session", columnTypes_e::intColumn, false);
 		return;
 	}
 

--- a/src/table.h
+++ b/src/table.h
@@ -99,6 +99,7 @@ namespace openset
 		public:
 			int rowCull{ 5000 }; // remove oldest rows if more than
 			int64_t stampCull{ 86400000LL * 365LL }; // auto cull older than
+			int64_t sessionTime{ 60000LL * 30LL }; // 30 minutes
 
 			explicit Table(string name, openset::db::Database* database);
 

--- a/src/table.h
+++ b/src/table.h
@@ -40,11 +40,11 @@ namespace openset
 		{
 			string segmentName;
 			int64_t refreshTime;
-			query::macro_s macros;
+			query::Macro_S macros;
 
 			segmentRefresh_s(
 				std::string segmentName, 
-				query::macro_s macros,
+				query::Macro_S macros,
 				int64_t refreshTime) :
 				segmentName(segmentName),
 				refreshTime(refreshTime),
@@ -196,7 +196,7 @@ namespace openset
 				return &triggerConf;
 			}
 
-			void setSegmentRefresh(std::string segmentName, query::macro_s macros, int64_t refreshTime)
+			void setSegmentRefresh(std::string segmentName, query::Macro_S macros, int64_t refreshTime)
 			{
 				csLock lock(segmentCS);
 				segmentRefresh.emplace(segmentName, segmentRefresh_s{ segmentName, macros, refreshTime });

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -39,7 +39,7 @@ openset::errors::Error Trigger::compileTrigger(
 	openset::db::Table* table, 
 	std::string name, 
 	std::string script,
-	openset::query::Macro_S &targetMacros)
+	openset::query::Macro_s &targetMacros)
 {
 
 /*

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -39,7 +39,7 @@ openset::errors::Error Trigger::compileTrigger(
 	openset::db::Table* table, 
 	std::string name, 
 	std::string script,
-	openset::query::macro_s &targetMacros)
+	openset::query::Macro_S &targetMacros)
 {
 
 /*
@@ -85,7 +85,7 @@ void Trigger::init()
 		delete bits;
 	}
 
-	interpreter = new openset::query::Interpreter(macros, openset::query::interpretMode_e::job);
+	interpreter = new openset::query::Interpreter(macros, openset::query::InterpretMode_e::job);
 
 	// This is the text value for this triggers on_insert event
 	auto valueName = settings->name + "::on_insert";

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -178,11 +178,11 @@ void Trigger::flushDirty()
 
 	auto oldAttr = attrPair->second; // keep it so we can delete it.
 
-	auto newAttr = recast<attr_s*>(
-		PoolMem::getPool().getPtr(sizeof(attr_s) + compBytes));
+	auto newAttr = recast<Attr_s*>(
+		PoolMem::getPool().getPtr(sizeof(Attr_s) + compBytes));
 
 	// copy header
-	std::memcpy(newAttr, oldAttr, sizeof(attr_s));
+	std::memcpy(newAttr, oldAttr, sizeof(Attr_s));
 	std::memcpy(newAttr->index, compData, compBytes);
 
 	// swap old index

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -130,7 +130,7 @@ namespace openset
 			std::string name;
 			std::string script;
 			int configVersion;
-			openset::query::Macro_S macros;
+			openset::query::Macro_s macros;
 		};
 
 		class Trigger
@@ -144,7 +144,7 @@ namespace openset
 			openset::db::Table* table;
 			openset::db::TablePartitioned* parts;
 
-			openset::query::Macro_S macros; // this will be a copy of what is in the triggerSettings_S
+			openset::query::Macro_s macros; // this will be a copy of what is in the triggerSettings_S
 			openset::query::Interpreter* interpreter;
 
 			openset::db::Person* person;
@@ -169,7 +169,7 @@ namespace openset
 				openset::db::Table* table, 
 				std::string name, 
 				std::string script,
-				openset::query::Macro_S &targetMacros);
+				openset::query::Macro_s &targetMacros);
 
 			void init();
 

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -31,7 +31,7 @@ namespace openset
 		class TablePartitioned;
 		class Attributes;
 		class IndexBits;
-		struct attr_s;
+		struct Attr_s;
 	};
 
 };
@@ -149,7 +149,7 @@ namespace openset
 
 			openset::db::Person* person;
 
-			openset::db::attr_s* attr;
+			openset::db::Attr_s* attr;
 			openset::db::IndexBits* bits;
 
 			int64_t currentFunctionHash;

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -130,7 +130,7 @@ namespace openset
 			std::string name;
 			std::string script;
 			int configVersion;
-			openset::query::macro_s macros;
+			openset::query::Macro_S macros;
 		};
 
 		class Trigger
@@ -144,7 +144,7 @@ namespace openset
 			openset::db::Table* table;
 			openset::db::TablePartitioned* parts;
 
-			openset::query::macro_s macros; // this will be a copy of what is in the triggerSettings_S
+			openset::query::Macro_S macros; // this will be a copy of what is in the triggerSettings_S
 			openset::query::Interpreter* interpreter;
 
 			openset::db::Person* person;
@@ -169,7 +169,7 @@ namespace openset
 				openset::db::Table* table, 
 				std::string name, 
 				std::string script,
-				openset::query::macro_s &targetMacros);
+				openset::query::Macro_S &targetMacros);
 
 			void init();
 

--- a/src/ver.h
+++ b/src/ver.h
@@ -3,5 +3,5 @@
 
 // line 6 is version
 const std::string __version__ = 
-"0.0.85"
+"0.0.86"
 ;

--- a/test/test_complex_events.h
+++ b/test/test_complex_events.h
@@ -148,7 +148,7 @@ inline Tests test_complex_events()
 					auto table = database->getTable("__test002__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this

--- a/test/test_complex_events.h
+++ b/test/test_complex_events.h
@@ -148,7 +148,7 @@ inline Tests test_complex_events()
 					auto table = database->getTable("__test002__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this

--- a/test/test_db.h
+++ b/test/test_db.h
@@ -277,7 +277,7 @@ inline Tests test_db()
 				auto table = database->getTable("__test001__");
 				auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-				openset::query::Macro_S queryMacros; // this is our compiled code block
+				openset::query::Macro_s queryMacros; // this is our compiled code block
 				openset::query::QueryParser p;
 
 				// compile this
@@ -373,7 +373,7 @@ inline Tests test_db()
 				auto table = database->getTable("__test001__");
 				auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-				openset::query::Macro_S queryMacros; // this is our compiled code block
+				openset::query::Macro_s queryMacros; // this is our compiled code block
 				openset::query::QueryParser p;
 
 				// compile this - passing in the template vars
@@ -460,7 +460,7 @@ inline Tests test_db()
 				auto table = database->getTable("__test001__");
 				auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-				openset::query::Macro_S queryMacros; // this is our compiled code block
+				openset::query::Macro_s queryMacros; // this is our compiled code block
 				openset::query::QueryParser p;
 
 				// compile this - passing in the template vars

--- a/test/test_db.h
+++ b/test/test_db.h
@@ -159,13 +159,13 @@ inline Tests test_db()
 				ASSERT(columns != nullptr);
 
 				// content (adding to 2000 range, these typically auto enumerated on create)
-				columns->setColumn(2000, "page", openset::db::columnTypes_e::textColumn, false, 0);
+				columns->setColumn(2000, "page", openset::db::columnTypes_e::textColumn, false);
 				// referral (adding to 3000 range)
-				columns->setColumn(3000, "referral_source", openset::db::columnTypes_e::textColumn, false, 0);
-				columns->setColumn(3001, "referral_search", openset::db::columnTypes_e::textColumn, false, 0);
+				columns->setColumn(3000, "referral_source", openset::db::columnTypes_e::textColumn, false);
+				columns->setColumn(3001, "referral_search", openset::db::columnTypes_e::textColumn, false);
 
-				// do we have 9 columns (5 built ins plus 4 we added)
-				ASSERT(table->getColumns()->columnCount == 8);
+				// do we have 10 columns (7 built ins plus 3 we added)
+				ASSERT(table->getColumns()->columnCount == 10);
 			
 				// built-ins
 				ASSERT(table->getColumns()->nameMap.count("__triggers"));

--- a/test/test_db.h
+++ b/test/test_db.h
@@ -277,7 +277,7 @@ inline Tests test_db()
 				auto table = database->getTable("__test001__");
 				auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-				openset::query::macro_s queryMacros; // this is our compiled code block
+				openset::query::Macro_S queryMacros; // this is our compiled code block
 				openset::query::QueryParser p;
 
 				// compile this
@@ -373,7 +373,7 @@ inline Tests test_db()
 				auto table = database->getTable("__test001__");
 				auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-				openset::query::macro_s queryMacros; // this is our compiled code block
+				openset::query::Macro_S queryMacros; // this is our compiled code block
 				openset::query::QueryParser p;
 
 				// compile this - passing in the template vars
@@ -460,7 +460,7 @@ inline Tests test_db()
 				auto table = database->getTable("__test001__");
 				auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-				openset::query::macro_s queryMacros; // this is our compiled code block
+				openset::query::Macro_S queryMacros; // this is our compiled code block
 				openset::query::QueryParser p;
 
 				// compile this - passing in the template vars

--- a/test/test_pyql_language.h
+++ b/test/test_pyql_language.h
@@ -574,7 +574,7 @@ inline Tests test_pyql_language()
 
     # test slicing strings
 	some_string = 'the rain in spain'
-	
+
 	new_string = some_string[-5:]
 	debug(new_string == 'spain')
 
@@ -584,6 +584,7 @@ inline Tests test_pyql_language()
 	new_string = some_string[4:8]
 	debug(new_string == 'rain')
 
+	# test find and rfind
     index = some_string.find('rain')
 	debug(index == 4)
 
@@ -593,8 +594,64 @@ inline Tests test_pyql_language()
     index = some_string.find('in', 8)
 	debug(index == 9)
 
+    index = some_string.rfind('in', 0)
+	debug(index == 15)
+
+    index = some_string.rfind('the')
+	debug(index == 0)
+
+    index = some_string.rfind('rain', 8)
+	debug(index == 4)
+
     index = some_string.find('rain', 0, 7)
 	debug(index == -1)
+
+	# test split
+	some_string = 'see spot run'
+	parts = some_string.split(' ')
+	debug(parts[0] == 'see' and parts[1] == 'spot' and parts[2] == 'run')
+
+	some_string = 'this::is::fun'
+	parts = some_string.split('::')
+	debug(parts[0] == 'this' and parts[1] == 'is' and parts[2] == 'fun')
+
+	some_string = "this won't split"
+	parts = some_string.split('|')
+	debug(parts[0] == some_string)
+
+	# test strip
+
+	some_string = '\t  this is a string \r\n'
+	clean = some_string.strip()
+	debug(clean == 'this is a string')
+
+	some_string = "\t \n \r"
+	clean = some_string.strip()
+	debug(clean == '')
+	
+	some_url = "http://somehost.com/this/is/the/path?param1=one&param2=two&param3"
+	parts = url_decode(some_url)
+
+	debug(parts['host'] == 'somehost.com')
+    debug(parts['path'] == '/this/is/the/path')
+	debug(parts['query'] == 'param1=one&param2=two&param3')
+	debug(len(parts['params']) == 3)
+    debug(parts['params']['param1'] == 'one')
+    debug(parts['params']['param2'] == 'two')
+    debug(parts['params']['param3'] == True)
+
+	some_url = "/this/is/the/path?param1=one"
+	parts = url_decode(some_url)
+	debug(parts['host'] == None)
+    debug(parts['path'] == '/this/is/the/path')
+    debug(len(parts['params']) == 1)
+    debug(parts['params']['param1'] == 'one')
+
+	some_url = "/this/is/the/path"
+	parts = url_decode(some_url)
+	debug(parts['host'] == None)
+    debug(parts['path'] == '/this/is/the/path')
+    debug(len(parts['params']) == 0)
 
 	)pyql");
 

--- a/test/test_pyql_language.h
+++ b/test/test_pyql_language.h
@@ -519,32 +519,82 @@ inline Tests test_pyql_language()
 	// test sdk functions (1)
 	auto test16_pyql = fixIndent(R"pyql(
 
-		# bucket always rounds to the lower bucket
-		# it is useful when generating distributions
+	# bucket always rounds to the lower bucket
+	# it is useful when generating distributions
 
-		debug(bucket(513, 25) == 500)
-		debug(bucket(525, 25) == 525)
-		debug(bucket(551, 25) == 550)
-		debug(bucket(5.11, 0.25) == 5.00)
-		debug(bucket(5.25, 0.25) == 5.25)
-		debug(bucket(5.51, 0.25) == 5.50)
+	debug(bucket(513, 25) == 500)
+	debug(bucket(525, 25) == 525)
+	debug(bucket(551, 25) == 550)
+	debug(bucket(5.11, 0.25) == 5.00)
+	debug(bucket(5.25, 0.25) == 5.25)
+	debug(bucket(5.51, 0.25) == 5.50)
 
-		# fix fixes a floating point number to
-        # a rounded set number of decimals and
-		# returns a string. Fix is useful for
-		# grouping where you likely want
-        # a consistent fixed precision group
-        # name.
+	# fix fixes a floating point number to
+    # a rounded set number of decimals and
+	# returns a string. Fix is useful for
+	# grouping where you likely want
+    # a consistent fixed precision group
+    # name.
 
-		debug(fix(0.01111, 2) == "0.01")
-		debug(fix(0.015, 2) == "0.02")
-		debug(fix(1234.5678, 2) == "1234.57")
-		debug(fix(1234.5678, 0) == "1235")
-		debug(fix(-0.01111, 2) == "-0.01")
-		debug(fix(-0.015, 2) == "-0.02")
-		debug(fix(-1234.5678, 2) == "-1234.57")
-		debug(fix(-1234.5678, 0) == "-1235")
+	debug(fix(0.01111, 2) == "0.01")
+	debug(fix(0.015, 2) == "0.02")
+	debug(fix(1234.5678, 2) == "1234.57")
+	debug(fix(1234.5678, 0) == "1235")
+	debug(fix(-0.01111, 2) == "-0.01")
+	debug(fix(-0.015, 2) == "-0.02")
+	debug(fix(-1234.5678, 2) == "-1234.57")
+	debug(fix(-1234.5678, 0) == "-1235")
 
+
+	)pyql");
+
+	// test slicing of strings and arrays
+	auto test17_pyql = fixIndent(R"pyql(
+
+    # test slicing lists
+    some_array = ['zero', 'one', 'two', 'three', 'four', 'five']
+
+	new_array = some_array[1:3]
+	debug(len(new_array) == 2 and new_array[0] == 'one' and new_array[1] == 'two')
+
+	new_array = some_array[:2]
+	debug(len(new_array) == 2 and new_array[0] == 'zero' and new_array[1] == 'one')
+
+	new_array = some_array[2:]
+	debug(len(new_array) == 4 and new_array[0] == 'two')
+
+	new_array = some_array[:]
+	debug(len(new_array) == 6 and new_array[0] == 'zero' and new_array[5] == 'five')
+
+	new_array = some_array[-1:]
+	debug(len(new_array) == 1 and new_array[0] == 'five')
+
+	new_array = some_array[-3:-2]
+	debug(len(new_array) == 1 and new_array[0] == 'three')
+
+    # test slicing strings
+	some_string = 'the rain in spain'
+	
+	new_string = some_string[-5:]
+	debug(new_string == 'spain')
+
+	new_string = some_string[:3]
+	debug(new_string == 'the')
+
+	new_string = some_string[4:8]
+	debug(new_string == 'rain')
+
+    index = some_string.find('rain')
+	debug(index == 4)
+
+    index = some_string.find('teeth')
+	debug(index == -1)
+
+    index = some_string.find('in', 8)
+	debug(index == 9)
+
+    index = some_string.find('rain', 0, 7)
+	debug(index == -1)
 
 	)pyql");
 
@@ -659,7 +709,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -709,7 +759,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -745,10 +795,7 @@ inline Tests test_pyql_language()
 					interpreter->exec();
 					ASSERT(interpreter->error.inError() == false);
 
-					auto debug = &interpreter->debugLog;
-
-					ASSERT(debug->size() == 1);
-					ASSERT(debug->at(0) == 1);
+					ASSERT(testAllTrue(interpreter->debugLog));
 				}
 				},
 				{
@@ -759,7 +806,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -810,7 +857,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -861,7 +908,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -914,7 +961,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -967,7 +1014,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1020,7 +1067,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1067,7 +1114,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1120,7 +1167,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1172,7 +1219,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1223,7 +1270,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1273,7 +1320,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1323,7 +1370,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1373,7 +1420,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1423,7 +1470,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::macro_s queryMacros; // this is our compiled code block
+					openset::query::Macro_S queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1463,6 +1510,56 @@ inline Tests test_pyql_language()
 
 					ASSERT(testAllTrue(interpreter->debugLog));
 				}
+			},
+			{
+				"test_pyql_language: test slicing of lists and strings", [test17_pyql]
+				{
+					auto database = openset::globals::database;
+
+					auto table = database->getTable("__test003__");
+					auto parts = table->getPartitionObjects(0); // partition zero for test				
+
+					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::QueryParser p;
+
+					// compile this
+					p.compileQuery(test17_pyql.c_str(), table->getColumns(), queryMacros);
+					ASSERTMSG(p.error.inError() == false, p.error.getErrorJSON());
+
+					//cout << OpenSet::query::MacroDbg(queryMacros) << endl;
+
+					// mount the compiled query to an interpretor
+					auto interpreter = new openset::query::Interpreter(queryMacros);
+
+					openset::result::ResultSet resultSet;
+					interpreter->setResultObject(&resultSet);
+
+					auto personRaw = parts->people.getmakePerson("user1@test.com"); // get a user			
+					ASSERT(personRaw != nullptr);
+					auto mappedColumns = interpreter->getReferencedColumns();
+
+					// MappedColumns? Why? Because the basic mapTable function (without a 
+					// columnList) maps all the columns in the table - which is what we want when 
+					// inserting or updating rows but means more processing and less data affinity
+					// when performing queries
+
+					Person person; // Person overlay for personRaw;
+					person.mapTable(table, 0, mappedColumns);
+
+					person.mount(personRaw); // this tells the person object where the raw compressed data is
+					person.prepare(); // this actually decompresses
+
+									  // this mounts the now decompressed data (in the person overlay)
+									  // into the interpreter
+					interpreter->mount(&person);
+
+					// run it
+					interpreter->exec();
+					ASSERTMSG(interpreter->error.inError() == false, interpreter->error.getErrorJSON());
+
+					ASSERT(testAllTrue(interpreter->debugLog));
+				}
 			}
+
 	};
 }

--- a/test/test_pyql_language.h
+++ b/test/test_pyql_language.h
@@ -766,7 +766,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -816,7 +816,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -852,7 +852,7 @@ inline Tests test_pyql_language()
 					interpreter->exec();
 					ASSERT(interpreter->error.inError() == false);
 
-					ASSERT(testAllTrue(interpreter->debugLog));
+					ASSERTDEBUGLOG(interpreter->debugLog);
 				}
 				},
 				{
@@ -863,7 +863,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -914,7 +914,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -965,7 +965,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1018,7 +1018,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1071,7 +1071,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1124,7 +1124,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1171,7 +1171,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1224,7 +1224,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1276,7 +1276,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1327,7 +1327,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1366,7 +1366,7 @@ inline Tests test_pyql_language()
 					ASSERTMSG(interpreter->error.inError() == false, interpreter->error.getErrorJSON());
 					
 					ASSERT(interpreter->debugLog.size() == 8);
-					ASSERT(testAllTrue(interpreter->debugLog));
+					ASSERTDEBUGLOG(interpreter->debugLog);
 				}
 				},
 				{
@@ -1377,7 +1377,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1416,7 +1416,7 @@ inline Tests test_pyql_language()
 					ASSERTMSG(interpreter->error.inError() == false, interpreter->error.getErrorJSON());
 
 					ASSERT(interpreter->debugLog.size() == 9);
-					ASSERT(testAllTrue(interpreter->debugLog));
+					ASSERTDEBUGLOG(interpreter->debugLog);
 				}
 				},
 				{
@@ -1427,7 +1427,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1466,7 +1466,7 @@ inline Tests test_pyql_language()
 					ASSERTMSG(interpreter->error.inError() == false, interpreter->error.getErrorJSON());
 
 					ASSERT(interpreter->debugLog.size() == 22);
-					ASSERT(testAllTrue(interpreter->debugLog));
+					ASSERTDEBUGLOG(interpreter->debugLog);
 				}
 			},
 			{
@@ -1477,7 +1477,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1516,7 +1516,7 @@ inline Tests test_pyql_language()
 					ASSERTMSG(interpreter->error.inError() == false, interpreter->error.getErrorJSON());
 
 					ASSERT(interpreter->debugLog.size() == 9);
-					ASSERT(testAllTrue(interpreter->debugLog));
+					ASSERTDEBUGLOG(interpreter->debugLog);
 				}
 			},
 			{
@@ -1527,7 +1527,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1565,7 +1565,7 @@ inline Tests test_pyql_language()
 					interpreter->exec();
 					ASSERTMSG(interpreter->error.inError() == false, interpreter->error.getErrorJSON());
 
-					ASSERT(testAllTrue(interpreter->debugLog));
+					ASSERTDEBUGLOG(interpreter->debugLog);
 				}
 			},
 			{
@@ -1576,7 +1576,7 @@ inline Tests test_pyql_language()
 					auto table = database->getTable("__test003__");
 					auto parts = table->getPartitionObjects(0); // partition zero for test				
 
-					openset::query::Macro_S queryMacros; // this is our compiled code block
+					openset::query::Macro_s queryMacros; // this is our compiled code block
 					openset::query::QueryParser p;
 
 					// compile this
@@ -1614,7 +1614,7 @@ inline Tests test_pyql_language()
 					interpreter->exec();
 					ASSERTMSG(interpreter->error.inError() == false, interpreter->error.getErrorJSON());
 
-					ASSERT(testAllTrue(interpreter->debugLog));
+					ASSERTDEBUGLOG(interpreter->debugLog);
 				}
 			}
 

--- a/test/test_sessions.h
+++ b/test/test_sessions.h
@@ -114,9 +114,8 @@ inline Tests test_sessions()
 	auto test1_pyql = fixIndent(R"pyql(
 	agg:
 		count person
-		distinct session
+		count session
         count some_val
-		distinct some_str
 
 	match:
 		tally("all", some_str)
@@ -293,7 +292,7 @@ inline Tests test_sessions()
 				auto totalsNode = dataNodes[0]->xPath("/c");
 				auto values = cjson::Stringify(totalsNode);
 
-				ASSERT(values == "[1,3,9,6]");
+				ASSERT(values == "[1,3,9]");
 
 			}
 		},

--- a/test/test_sessions.h
+++ b/test/test_sessions.h
@@ -1,0 +1,303 @@
+#pragma once
+
+#include "testing.h"
+
+#include "../lib/cjson/cjson.h"
+#include "../lib/str/strtools.h"
+#include "../lib/var/var.h"
+#include "../src/database.h"
+#include "../src/table.h"
+#include "../src/columns.h"
+#include "../src/asyncpool.h"
+#include "../src/tablepartitioned.h"
+#include "../src/queryinterpreter.h"
+#include "../src/queryparser.h"
+#include "../src/internoderouter.h"
+#include "../src/result.h"
+
+#include <unordered_set>
+
+// Our tests
+inline Tests test_sessions()
+{
+	
+	// An array of JSON events to insert, we are going to 
+	// insert these out of order and count on zorder to
+	// sort them.
+	// we will set zorder for action to "alpha", "beta", "cappa", "delta", "echo"
+	auto user1_raw_inserts = R"raw_inserts(
+	[
+		{
+			"uuid": "user1@test.com",
+			"stamp": 1458800000,
+			"action": "some event",
+			"attr":{				
+				"some_val": 100,
+	            "some_str": "rabbit"
+			}
+		},
+		{
+			"uuid": "user1@test.com",
+			"stamp": 1458800100,
+			"action": "some event",
+			"attr":{				
+				"some_val": 101,
+	            "some_str": "train"
+			}
+		},
+		{
+			"uuid": "user1@test.com",
+			"stamp": 1458800200,
+			"action": "some event",
+			"attr":{				
+				"some_val": 102,
+	            "some_str": "cat"
+			}
+		},
+		{
+			"uuid": "user1@test.com",
+			"stamp": 1545220000,
+			"action": "some event",
+			"attr":{				
+				"some_val": 103,
+	            "some_str": "dog"
+			}
+		},
+		{
+			"uuid": "user1@test.com",
+			"stamp": 1545220100,
+			"action": "some event",
+			"attr":{				
+				"some_val": 104,
+	            "some_str": "cat"
+			}
+		},
+		{
+			"uuid": "user1@test.com",
+			"stamp": 1545220900,
+			"action": "some event",
+			"attr":{				
+				"some_val": 105,
+	            "some_str": "rabbit"
+			}
+		},
+		{
+			"uuid": "user1@test.com",
+			"stamp": 1631600000,
+			"action": "some event",
+			"attr":{				
+				"some_val": 106,
+	            "some_str": "train"
+			}
+		},
+		{
+			"uuid": "user1@test.com",
+			"stamp": 1631600400,
+			"action": "some event",
+			"attr":{				
+				"some_val": 107,
+	            "some_str": "plane"
+			}
+		},
+		{
+			"uuid": "user1@test.com",
+			"stamp": 1631601200,
+			"action": "some event",
+			"attr":{				
+				"some_val": 108,
+	            "some_str": "automobile"
+			}
+		},
+	]
+	)raw_inserts";
+	
+	auto test1_pyql = fixIndent(R"pyql(
+	agg:
+		count person
+		distinct session
+        count some_val
+		distinct some_str
+
+	match:
+		tally("all", some_str)
+		if session == 2:
+			debug(true)
+
+	debug(session_count == 3)
+
+	)pyql");
+
+
+	/* In order to make the engine start there are a few required objects as 
+	 * they will get called in the background during testing:
+	 *   
+	 *  - cfg::manager must exist // cfg::initConfig)
+	 *  - __AsyncManager must exist // new OpenSet::async::AyncPool(...)
+	 *  - Databse must exist // databases contain tabiles
+	 *  
+	 *  These objects will be created on the heap, although in practice during
+	 *  the construction phase these are created as local objects to other classes.
+	 */
+
+	// need config objects to run this
+	openset::config::CommandlineArgs args;
+	openset::globals::running = new openset::config::Config(args); 
+
+	// stop load/save objects from doing anything
+	openset::globals::running->testMode = true; 
+
+	// we need an async engine, although we won't really be using it, 
+	// it's wired into the into features such as tablePartitioned (shared locks mostly)
+	openset::async::AsyncPool* async = new openset::async::AsyncPool(1, 1); // 1 worker
+
+	openset::mapping::PartitionMap partitionMap;
+	// this must be on heap to keep it in scope
+	openset::mapping::Mapper* mapper = new openset::mapping::Mapper();
+	mapper->startRouter();
+
+
+	// put engine in a wait state otherwise we will throw an exception
+	async->suspendAsync();
+
+	auto database = new Database();
+
+	return {
+		{
+			"test_sessions: create and prepare a table", [database, user1_raw_inserts] {
+
+				// prepare our table
+				auto table = database->newTable("__test004__");
+
+				// add some columns
+				auto columns = table->getColumns();
+				ASSERT(columns != nullptr);
+
+				// content (adding to 2000 range, these typically auto enumerated on create)
+				columns->setColumn(2000, "some_val", openset::db::columnTypes_e::intColumn, false);
+				columns->setColumn(2001, "some_str", openset::db::columnTypes_e::textColumn, false);
+			
+				auto parts = table->getPartitionObjects(0); // partition zero for test
+				auto personRaw = parts->people.getmakePerson("user1@test.com");
+
+				Person person; // Person overlay for personRaw;
+
+				person.mapTable(table, 0); // will throw in DEBUG if not called before mount
+				person.mount(personRaw);
+
+				// parse the user1_raw_inserts raw JSON text block
+				cjson insertJSON(user1_raw_inserts, strlen(user1_raw_inserts));
+
+				// get vector of cjson nodes for each element in root array
+				auto events = insertJSON.getNodes();
+
+				for (auto e : events)
+				{
+					ASSERT(e->xPathInt("/stamp", 0) != 0);
+					ASSERT(e->xPath("/attr") != nullptr);
+
+					person.insert(e);
+				}
+
+				auto grid = person.getGrid();
+				auto json = grid->toJSON(false); // non-condensed
+
+				person.commit();
+
+			}
+		},
+		{
+			"test_sessions: loop", [test1_pyql]
+			{
+				auto database = openset::globals::database;
+
+				auto table = database->getTable("__test004__");
+				auto parts = table->getPartitionObjects(0); // partition zero for test				
+
+				openset::query::Macro_s queryMacros; // this is our compiled code block
+				openset::query::QueryParser p;
+
+				// compile this
+				p.compileQuery(test1_pyql.c_str(), table->getColumns(), queryMacros);
+				ASSERT(p.error.inError() == false);
+
+				// mount the compiled query to an interpretor
+				auto interpreter = new openset::query::Interpreter(queryMacros);
+
+				openset::result::ResultSet resultSet;
+				interpreter->setResultObject(&resultSet);
+
+				auto personRaw = parts->people.getmakePerson("user1@test.com"); // get a user			
+				ASSERT(personRaw != nullptr);
+				auto mappedColumns = interpreter->getReferencedColumns();
+
+				// MappedColumns? Why? Because the basic mapTable function (without a 
+				// columnList) maps all the columns in the table - which is what we want when 
+				// inserting or updating rows but means more processing and less data affinity
+				// when performing queries
+
+				Person person; // Person overlay for personRaw;
+				person.mapTable(table, 0, mappedColumns);
+
+				person.mount(personRaw); // this tells the person object where the raw compressed data is
+				person.prepare(); // this actually decompresses
+
+								  // this mounts the now decompressed data (in the person overlay)
+								  // into the interpreter
+				interpreter->mount(&person);
+
+				// run it
+				interpreter->exec();
+				ASSERT(interpreter->error.inError() == false);
+
+				// just getting a pointer to the results for nicer readability
+				auto result = interpreter->result;
+
+				ASSERT(result->results.size() != 0);
+
+				// we are going to sort the list, this is done for merging, but
+				// being we have one partition in this test we won't actually be merging.
+				result->makeSortedList();
+
+				// the merger was made to merge a fancy result structure, we
+				// are going to manually stuff our result into this
+				std::vector<openset::result::ResultSet*> resultSets;
+
+				// populate or vector of results, so we can merge
+				//responseData.push_back(&res);
+				resultSets.push_back(interpreter->result);
+
+				// this is the merging object, it merges results from multiple 
+				// partitions into a result that can serialized to JSON, or to 
+				// binary for distributed queries
+				openset::result::ResultMuxDemux merger;
+
+				// we are going to populate this
+				cjson resultJSON;
+
+				// make some JSON
+				auto rows = merger.mergeResultSets(queryMacros, table, resultSets);
+				auto text = merger.mergeText(queryMacros, table, resultSets);
+				merger.resultSetToJSON(queryMacros, table, &resultJSON, rows, text);
+
+				// NOTE - uncomment if you want to see the results
+				//cout << cjson::Stringify(&resultJSON, true) << endl;
+
+				ASSERTDEBUGLOG(interpreter->debugLog);
+
+				auto underScoreNode = resultJSON.xPath("/_");
+				ASSERT(underScoreNode != nullptr);
+
+				auto dataNodes = underScoreNode->getNodes();
+				ASSERT(dataNodes.size() == 1);
+
+				auto totalsNode = dataNodes[0]->xPath("/c");
+				auto values = cjson::Stringify(totalsNode);
+
+				ASSERT(values == "[1,3,9,6]");
+
+			}
+		},
+
+	};
+
+}

--- a/test/test_zorder.h
+++ b/test/test_zorder.h
@@ -181,7 +181,7 @@ inline Tests test_zorder()
 
 	return {
 		{
-			"db: create and prepare a table", [database, user1_raw_inserts] {
+			"z-order: test event z-order", [database, user1_raw_inserts] {
 
 				// prepare our table
 				auto table = database->newTable("__test001__");

--- a/test/testing.h
+++ b/test/testing.h
@@ -40,7 +40,7 @@ struct TestFail_s
 	int line;
 	std::string message;
 
-	TestFail_s(const char* expression, const char* file, int line, std::string message) :
+	TestFail_s(const char* expression, const char* file, const int line, const std::string message) :
 		expression(std::string{ expression }),
 		file(std::string{ file }),
 		line(line),

--- a/test/testing.h
+++ b/test/testing.h
@@ -33,7 +33,6 @@ inline void incrFailed()
 	++testsFailed;
 }
 
-
 struct TestFail_s
 {
 	std::string expression;

--- a/test/testing.h
+++ b/test/testing.h
@@ -58,12 +58,17 @@ inline bool testAllTrue(std::vector<cvar> &debugLog)
 		debugLog.end(), 
 		[](bool test)
 	{
+		if (test)
+			incrPassed();
+		else
+			incrFailed();
 		return test;
 	});
 }
 
 #define ASSERTMSG(condition, message) ((condition) ? incrPassed() : throw TestFail_s({#condition,__FILE__,__LINE__,message}))
 #define ASSERT(condition) ((condition) ? incrPassed() : throw TestFail_s({#condition,__FILE__,__LINE__,""}))
+#define ASSERTDEBUGLOG(conditions) (testAllTrue(conditions) ? true : throw TestFail_s({#conditions,__FILE__,__LINE__,"sub-test failed"}))
 
 using Tests = std::vector<TestItem_s>;
 using Fails = std::vector<TestFail_s>;
@@ -73,7 +78,7 @@ using Fails = std::vector<TestFail_s>;
 // this detects the indent level and pulls it out and returns
 // a new string void of empty lines, tabs expanded and 
 // de-indented so the pyql parser can process it
-inline std::string fixIndent(std::string source)
+inline std::string fixIndent(const std::string source)
 {
 
 	std::vector<string> res;
@@ -152,9 +157,9 @@ inline Fails runTests(Tests &tests)
 	}
 
 	cout << "------------------------------------------------------" << endl;
-	cout << "RAN    " << (testsPassed + testsFailed) << endl;
-	cout << "PASSED " << testsPassed << endl;
-	cout << "FAILED " << testsFailed << endl;
-	
+	cout << "TESTS RAN    " << (testsPassed + testsFailed) << endl;
+	cout << "TESTS PASSED " << testsPassed << endl;
+	cout << "TESTS FAILED " << testsFailed << endl;
+
 	return failed;
 }

--- a/test/unittests.h
+++ b/test/unittests.h
@@ -6,6 +6,7 @@
 #include "test_complex_events.h"
 #include "test_pyql_language.h"
 #include "test_zorder.h"
+#include "test_sessions.h"
 #include "../src/logger.h"
 
 bool unitTest()
@@ -25,6 +26,7 @@ bool unitTest()
 	add(test_complex_events());
 	add(test_pyql_language());
 	add(test_zorder());
+	add(test_sessions());
 
 	return runTests(allTests).size() == 0; // true if zero
 }


### PR DESCRIPTION
Adding support for more string functions in PyQL. Python syntax splicing works on both strings, and lists and supports negative indexing  (it does not support skipping). 
```
some_string = 'the rain in spain'
	
new_string = some_string[-5:]
debug(new_string == 'spain')

new_string = some_string[:3]
debug(new_string == 'the')

new_string = some_string[4:8]
debug(new_string == 'rain')

index = some_string.find('rain')
debug(index == 4)

index = some_string.find('teeth')
debug(index == -1)

index = some_string.find('in', 8)
debug(index == 9)

index = some_string.find('rain', 0, 7)
debug(index == -1)
```