### PR TITLE
less wasteful indexes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 
 elseif(CMAKE_BUILD_TYPE MATCHES Release)
 	if (MSVC)
-		add_definitions(-D_CRT_SECURE_NO_WARNINGS /std:c++17 /O2)
+		add_definitions(-D_CRT_SECURE_NO_WARNINGS /std:c++17 /Ox)
 	else()
 		add_definitions(-m64 -std=c++17 -pthread -g -static -static-libstdc++ -static-libgcc -msse2 -o3 -fexpensive-optimizations -ftree-vectorize -fprefetch-loop-arrays -funroll-loops)
 	endif()

--- a/lib/threads/spinlock.h
+++ b/lib/threads/spinlock.h
@@ -48,10 +48,10 @@ public:
 
 		do
 		{
-			while (locked.load(std::memory_order_relaxed))
+			while (locked.load(std::memory_order_relaxed));
 #ifdef _MSC_VER
 				_mm_pause();
-#elif (COMPILER == GCC || COMPILER == LLVM)
+#else
 				asm("pause");
 #endif
 		}

--- a/src/asyncloop.cpp
+++ b/src/asyncloop.cpp
@@ -99,7 +99,7 @@ bool AsyncLoop::Run(int64_t &nextRun)
 	// it will call each job that is ready to run
 	for (auto w : active)
 	{
-		auto now = Now();
+		const auto now = Now();
 
 		if (!w->prepared)
 		{

--- a/src/asyncpool.cpp
+++ b/src/asyncpool.cpp
@@ -316,21 +316,21 @@ void AsyncPool::runner(int32_t workerId) noexcept
 			globalAsyncSuspendedWorkerCount -= 1;
 		}
 
-		// using a C++11 conditional lock (eventing) so that if
-		// we aren't tasked up, we can wait for a cell to be added, or 1000ms
 
-		//if (!runAgain)
+		if (!runAgain)
 		{ // we don't need the lock, so we will exit the moment we have it
 
-			if (nextRun == -1)
-				nextRun = Now() + 250;
 
-			auto delay = nextRun - Now();
+			auto delay = (nextRun == -1) ? 250 : nextRun - Now();
+
 			if (delay < 0) 
 				delay = 0;
 
-			if (!worker->triggered)
+			if (delay && !worker->triggered)
 			{
+				// using a C++11 conditional lock (eventing) so that if
+				// we aren't tasked up, we can wait for a cell to be added, or 250ms
+
 				unique_lock<std::mutex> lock(worker->lock);
 				worker->conditional.wait_for(lock, std::chrono::milliseconds(delay), [&]() -> bool
 				{

--- a/src/attributeblob.cpp
+++ b/src/attributeblob.cpp
@@ -47,7 +47,7 @@ char* openset::db::AttributeBlob::storeValue(int32_t column, string value)
 char* openset::db::AttributeBlob::getValue(int32_t column, int64_t valueHash)
 {
 	char* blob = nullptr;
-	auto key = attr_key_s::makeKey(column, valueHash);
+	const auto key = attr_key_s::makeKey(column, valueHash);
 
 	csLock lock(cs);
 	attributesBlob.get(key, blob);

--- a/src/attributeblob.cpp
+++ b/src/attributeblob.cpp
@@ -1,42 +1,41 @@
 #include "attributeblob.h"
 #include "sba/sba.h"
 
-openset::db::AttributeBlob::AttributeBlob():
-	attributesBlob(ringHint_e::lt_compact)
+openset::db::AttributeBlob::AttributeBlob()
 {}
 
 openset::db::AttributeBlob::~AttributeBlob()
 {}
 
-bool openset::db::AttributeBlob::isAttribute(int32_t column, int64_t valueHash) 
+bool openset::db::AttributeBlob::isAttribute(const int32_t column, const int64_t valueHash)
 {
 	csLock lock(cs);
 	return attributesBlob.count(attr_key_s::makeKey(column, valueHash));
 }
 
-bool openset::db::AttributeBlob::isAttribute(int32_t column, string value) 
+bool openset::db::AttributeBlob::isAttribute(const int32_t column, const string& value)
 {
 	// TODO iterate for collisions
-	auto valueHash = MakeHash(value);
+	const auto valueHash = MakeHash(value);
 
 	csLock lock(cs);
 	return attributesBlob.count(attr_key_s::makeKey(column, valueHash));
 }
 
-char* openset::db::AttributeBlob::storeValue(int32_t column, string value)
+char* openset::db::AttributeBlob::storeValue(const int32_t column, const string& value)
 {
-	auto valueHash = MakeHash(value);
+	const auto valueHash = MakeHash(value);
 	char* blob = nullptr;
 
-	auto key = attr_key_s::makeKey(column, valueHash);
+	const auto key = attr_key_s::makeKey(column, valueHash);
 
 	csLock lock(cs);
 
 	if (!attributesBlob.get(key, blob))
 	{
 		// not found let's make it!
-		auto len = value.length();
-		blob = cast<char*>(PoolMem::getPool().getPtr(len + 1));
+		const auto len = value.length();
+		blob = mem.newPtr(len + 1);//cast<char*>(PoolMem::getPool().getPtr(len + 1));
 		strcpy(blob, value.c_str());
 		attributesBlob.set(key, blob);
 	}
@@ -44,7 +43,7 @@ char* openset::db::AttributeBlob::storeValue(int32_t column, string value)
 	return blob;
 }
 
-char* openset::db::AttributeBlob::getValue(int32_t column, int64_t valueHash)
+char* openset::db::AttributeBlob::getValue(const int32_t column, const int64_t valueHash)
 {
 	char* blob = nullptr;
 	const auto key = attr_key_s::makeKey(column, valueHash);

--- a/src/attributeblob.h
+++ b/src/attributeblob.h
@@ -5,6 +5,7 @@
 
 #include "threads/locks.h"
 #include "mem/bigring.h"
+#include "heapstack/heapstack.h"
 
 using namespace std;
 
@@ -14,18 +15,19 @@ namespace openset
 	{
 		class AttributeBlob
 		{
-			bigRing<attr_key_s, char*> attributesBlob;
+			bigRing<attr_key_s, char*> attributesBlob{ ringHint_e::lt_1_million };
+			HeapStack mem;
 		public:
 
 			CriticalSection cs;
 			AttributeBlob();
 			~AttributeBlob();
 
-			bool isAttribute(int32_t column, int64_t valueHash);
-			bool isAttribute(int32_t column, string value);
-			char* storeValue(int32_t column, string value);
+			bool isAttribute(const int32_t column, const int64_t valueHash);
+			bool isAttribute(const int32_t column, const string& value);
+			char* storeValue(const int32_t column, const string& value);
 
-			char* getValue(int32_t column, int64_t valueHash);
+			char* getValue(const int32_t column, const int64_t valueHash);
 		};
 	};
 };

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -82,7 +82,8 @@ Attr_s* Attributes::getMake(const int32_t column, const string value)
 	if (auto attrPair = columnIndex->get(valueHash); attrPair == nullptr)
 	{
 		const auto attr = new(PoolMem::getPool().getPtr(sizeof(Attr_s)))Attr_s();
-		attr->text = blob->storeValue(column, value);
+		//attr->text = 
+		blob->storeValue(column, value);
 		attrPair = columnIndex->set(valueHash, attr);
 		return attrPair->second;
 	}
@@ -296,14 +297,17 @@ void Attributes::serialize(HeapStack* mem)
 			blockHeader->column = col.first;
 			blockHeader->hashValue = item.first;
 			blockHeader->ints = item.second->ints;
-			blockHeader->textSize = item.second->text ? strlen(item.second->text) : 0;
+			auto text = this->blob->getValue(col.first, item.first);
+			blockHeader->textSize = text ? strlen(text) : 0;
+			//blockHeader->textSize = item.second->text ? strlen(item.second->text) : 0;
 			blockHeader->compSize = item.second->comp;
 
 			// copy a text/blob value if any
 			if (blockHeader->textSize)
 			{
 				const auto textData = recast<char*>(mem->newPtr(blockHeader->textSize));
-				memcpy(textData, item.second->text, blockHeader->textSize);
+				memcpy(textData, text, blockHeader->textSize);
+				//memcpy(textData, item.second->text, blockHeader->textSize);
 			}
 
 			// copy the compressed data
@@ -364,7 +368,7 @@ int64_t Attributes::deserialize(char* mem)
 
 		// create an attr_s object
 		const auto attr = recast<Attr_s*>(PoolMem::getPool().getPtr(sizeof(Attr_s) + blockHeader->compSize));
-		attr->text = blobPtr;
+		//attr->text = blobPtr;
 		attr->ints = blockHeader->ints;
 		attr->comp = blockHeader->compSize;
 		attr->changeTail = nullptr;

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -78,7 +78,7 @@ namespace openset::db
 		 * 
 		 */
 		Attr_changes_s* changeTail{ nullptr };
-		char* text{ nullptr };
+		//char* text{ nullptr };
 		int32_t ints{ 0 }; // number of unsigned int64 integers uncompressed data uses
 		int32_t comp{ 0 }; // compressed size in bytes
 		int32_t linId{ -1 };

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -58,10 +58,30 @@ namespace openset::db
 	*/
 	struct Attr_s
 	{
+		/*
+		 * The Attr_s is an index structure. 
+		 *  
+		 * Standard layout:
+		 *   ints - the number of uint64_t in the bit index array decompressed
+		 *   comp - how much space they take compressed (in bytes)
+		 * 
+		 * Sparse Layout:
+		 *   ints - negative number, abs value is number of int32_ts in list
+		 *   comp - size of array in bytes (4 x length)
+		 * 
+		 * Note: some indexes are really sparce, and while they compress well
+		 *   if there are thousands or millions of bits, compressing just one or
+		 *   two bits can be a waste of processor cycles and space as the result
+		 *   is still larger than it need be. In situtations where the population
+		 *   of the index is low, we will use an array of int32_t values, where
+		 *   each int32_t is a linear_id (linear user id).
+		 * 
+		 */
 		Attr_changes_s* changeTail{ nullptr };
 		char* text{ nullptr };
 		int32_t ints{ 0 }; // number of unsigned int64 integers uncompressed data uses
 		int32_t comp{ 0 }; // compressed size in bytes
+		int32_t linId{ -1 };
 		char index[1]; // char* (1st byte) of packed index bits struct
 
 		Attr_s() {};

--- a/src/dbtypes.h
+++ b/src/dbtypes.h
@@ -91,9 +91,9 @@ namespace openset
 			int32_t column;
 			int64_t value;
 
-			static attr_key_s makeKey(int32_t Column, int64_t Value)
+			static attr_key_s makeKey(const int32_t column, const int64_t value)
 			{
-				return {Column, Value};
+				return {column, value};
 			}
 
 			bool operator==(const attr_key_s& other) const

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -290,8 +290,8 @@ cjson Grid::toJSON(const bool condensed) const
 						case columnTypes_e::textColumn:
 						{
 							// value here is the hashed value							
-							if (const auto attr = attributes->get(colInfo->idx, value); attr->text)
-								rowObj->set(colInfo->name, attr->text);
+							if (const auto text = attributes->blob->getValue(colInfo->idx, value); text)
+								rowObj->set(colInfo->name, text);
 						}
 						break;
 						}
@@ -343,8 +343,8 @@ cjson Grid::toJSON(const bool condensed) const
 							break;
 						case columnTypes_e::textColumn:
 						{							
-							if (const auto attr = attributes->get(colInfo->idx, value); attr && attr->text)
-								rowObj->set(colInfo->name, attr->text);
+							if (const auto text = attributes->blob->getValue(colInfo->idx, value); text)
+								rowObj->set(colInfo->name, text);
 						}
 						break;
 						}

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -958,7 +958,7 @@ void Grid::insert(cjson* rowData)
 				fillCount++;
 
 				auto attrInfo = attributes->getMake(schemaCol, NONE);
-				attributes->setDirty(this->rawData->linId, schemaCol, NONE, attrInfo);
+				attributes->setDirty(this->rawData->linId, schemaCol, NONE);
 				
 				auto val = NONE;
 
@@ -989,7 +989,7 @@ void Grid::insert(cjson* rowData)
 						default:
 							break;
 					}					
-					attributes->setDirty(this->rawData->linId, schemaCol, val, attrInfo);
+					attributes->setDirty(this->rawData->linId, schemaCol, val);
 					break;
 				case cjsonType::DBL:
 					switch (colInfo->type)
@@ -1016,7 +1016,7 @@ void Grid::insert(cjson* rowData)
 						default:
 							break;
 					}					
-					attributes->setDirty(this->rawData->linId, schemaCol, val, attrInfo);
+					attributes->setDirty(this->rawData->linId, schemaCol, val);
 					break;
 				case cjsonType::STR:
 					switch (colInfo->type)
@@ -1038,7 +1038,7 @@ void Grid::insert(cjson* rowData)
 					default:
 						break;
 					}
-					attributes->setDirty(this->rawData->linId, schemaCol, val, attrInfo);
+					attributes->setDirty(this->rawData->linId, schemaCol, val);
 					break;
 				case cjsonType::BOOL:
 					switch (colInfo->type)
@@ -1067,7 +1067,7 @@ void Grid::insert(cjson* rowData)
 					}
 
 					// attrInfo = attributes->getMake(schemaCol, val);
-					attributes->setDirty(this->rawData->linId, schemaCol, val, attrInfo);
+					attributes->setDirty(this->rawData->linId, schemaCol, val);
 					break;
 
 				default:

--- a/src/indexbits.h
+++ b/src/indexbits.h
@@ -26,25 +26,25 @@ namespace openset
 
 			// make bits that are on or off
 			// index is number of bits, state is 1 or 0
-			void makeBits(int64_t index, int state);
+			void makeBits(const int64_t index, const int state);
 
 			// takes buffer to compressed data and actual size as parameters
 			// note: actual size is number of long longs (in64_t)
-			void mount(char* compressedData, int32_t Ints);
+			void mount(char* compressedData, const int32_t integers, const int32_t linId);
 
 			int64_t getSizeBytes() const;
 
 			// returns a POOL buffer, and the number of bytes
 			// required for the stored data... obviously, and it's a pity
 			// we need to double copy the result.
-			char* store(int64_t& compressedBytes);
+			char* store(int64_t& compressedBytes, int32_t &linId);
 
-			void grow(int32_t Required);
+			void grow(const int32_t required);
 
-			void lastBit(int64_t index);
-			void bitSet(int64_t index);
-			void bitClear(int64_t index);
-			bool bitState(int64_t index) const;
+			void lastBit(const int64_t index);
+			void bitSet(const int64_t index);
+			void bitClear(const int64_t index);
+			bool bitState(const int64_t index) const;
 
 			int64_t population(int stopBit) const;
 
@@ -55,7 +55,7 @@ namespace openset
 			void opAndNot(IndexBits& source);
 			void opNot() const;
 
-			bool linearIter(int64_t& linId, int stopBit) const;
+			bool linearIter(int32_t& linId, int stopBit) const;
 
 			class BitProxy
 			{
@@ -64,7 +64,7 @@ namespace openset
 				int idx;
 				int value;
 
-				BitProxy(IndexBits* bits, int idx) :
+				BitProxy(IndexBits* bits, const int idx) :
 					bits(bits),
 					idx(idx)
 				{

--- a/src/internodeoutbound.cpp
+++ b/src/internodeoutbound.cpp
@@ -65,12 +65,11 @@ void openset::mapping::OutboundClient::runLocalLoop()
 			--backlogSize;
 		}
 
-		// TODO call the RPC handler...
-		auto iter = globals::server->handlers.find(message->getRPC());
-		if (iter != globals::server->handlers.end())
+		// TODO call the RPC handler...		
+		if (const auto iter = globals::server->handlers.find(message->getRPC()); iter != globals::server->handlers.end())
 		{
 			// call back the handler
-			auto cb = iter->second;
+			const auto cb = iter->second;
 			cb(message);
 		}
 		else
@@ -191,8 +190,6 @@ void openset::mapping::OutboundClient::runRemote()
 				message->dispose();
 		}
 	}
-
-	closeConnection();
 }
 
 void openset::mapping::OutboundClient::startRoute()
@@ -327,15 +324,13 @@ int32_t openset::mapping::OutboundClient::directRequest(comms::RouteHeader_s rou
 		return -1;
 
 	const char* headerPtr = recast<char*>(&routing);
-	auto headerLen = sizeof(comms::RouteHeader_s);
-	auto sent = 0;
+	const auto headerLen = sizeof(comms::RouteHeader_s);
 	auto total = 0;
-
 	routing.length = len;
 
 	while (total < headerLen)
 	{
-		sent = send(this->sock, headerPtr, headerLen - total, MSG_NOSIGNAL);
+		const auto sent = send(this->sock, headerPtr, headerLen - total, MSG_NOSIGNAL);
 
 		if (sent == SOCKET_ERROR)
 		{
@@ -350,12 +345,12 @@ int32_t openset::mapping::OutboundClient::directRequest(comms::RouteHeader_s rou
 	if (buffer == nullptr)
 		return 0;
 
-	const char* bufferPtr = buffer;
+	auto bufferPtr = buffer;
 	total = 0;
 
 	while (total < len)
 	{
-		sent = send(this->sock, bufferPtr, len - total, MSG_NOSIGNAL);
+		const auto sent = send(this->sock, bufferPtr, len - total, MSG_NOSIGNAL);
 
 		lastRx = Now();
 
@@ -401,13 +396,12 @@ openset::comms::RouteHeader_s openset::mapping::OutboundClient::waitDirectRespon
 
 	auto headerPtr = reinterpret_cast<char*>(&result);
 
-	auto headerLen = sizeof(comms::RouteHeader_s);
+	const auto headerLen = sizeof(comms::RouteHeader_s);
 	auto total = 0;
-	auto received = 0;
 
 	while (total < headerLen)
 	{
-		received = recv(sock, headerPtr, headerLen - total, 0);
+		const auto received = recv(sock, headerPtr, headerLen - total, 0);
 
 		lastRx = Now();
 
@@ -427,12 +421,12 @@ openset::comms::RouteHeader_s openset::mapping::OutboundClient::waitDirectRespon
 	if (result.length)
 	{
 		data = new char[result.length];
-		char* offset = data;
+		auto offset = data;
 		total = 0;
 
 		while (total < result.length)
 		{
-			received = recv(sock, offset, result.length - total, 0);
+			const auto received = recv(sock, offset, result.length - total, 0);
 
 			if (received <= 0)
 			{

--- a/src/internoderouter.cpp
+++ b/src/internoderouter.cpp
@@ -3,6 +3,7 @@
 #include "file/file.h"
 #include "config.h"
 
+#include "sba/sba.h"
 #include "internoderouter.h"
 #include "internodemessage.h"
 #include "internodeoutbound.h"
@@ -222,11 +223,7 @@ void openset::mapping::Mapper::disposeMessage(MessageID messageId)
 	}
 
 	if (message != messages.end())
-	{
 		delete message->second; // message destructor removes message
-		//csLock lock(cs);
-		//messages.erase(messageId);
-	}
 }
 
 class dispatchState

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,7 @@ int main(const int argc, char* argv[])
 		}
 	}
 
-//	if (test)
+  	if (test)
 	{
 		const auto testRes = unitTest();
 		exit(testRes ? 0 : 1); // exit with 1 on test fail

--- a/src/oloop.cpp
+++ b/src/oloop.cpp
@@ -64,7 +64,7 @@ void OpenLoop::suicide()
 
 bool OpenLoop::sliceComplete() const
 {
-	auto sliceDivisor = inBypass() ? 3 : 1;
+	const auto sliceDivisor = inBypass() ? 3 : 1;
 	return (Now() > runStart + (loop->runTime / sliceDivisor));
 }
 
@@ -73,7 +73,7 @@ bool OpenLoop::checkCondition()
 	return true; // always good
 }
 
-bool OpenLoop::checkTimer(int64_t milliNow)
+bool OpenLoop::checkTimer(const int64_t milliNow)
 {
 	return (milliNow >= runAt) ? true : false;
 }

--- a/src/oloop.h
+++ b/src/oloop.h
@@ -50,7 +50,7 @@ namespace openset
 
 			bool sliceComplete() const;
 			virtual bool checkCondition();
-			virtual bool checkTimer(int64_t milliNow);
+			virtual bool checkTimer(const int64_t milliNow);
 
 			// these must be overridden (preferrably final) in derived classes
 			virtual void prepare() = 0;

--- a/src/oloop_count.cpp
+++ b/src/oloop_count.cpp
@@ -94,6 +94,8 @@ void OpenLoopCount::storeSegments()
 
 			if (!bits) continue;
 
+			auto pop = bits->population(maxLinearId);
+
 			// make sure it exists in the index, we don't care about the return value
 			parts->attributes.getMake(COL_SEGMENT, segmentName);
 
@@ -252,7 +254,7 @@ void OpenLoopCount::prepare()
 	// require iterating user records (as in were cached, segmentMath, or indexed).
 	if (!nextMacro())
 	{
-		auto time = Now() - startTime;
+		const auto time = Now() - startTime;
 
 		openset::errors::Error error;
 
@@ -297,7 +299,7 @@ void OpenLoopCount::run()
 		// if there was an error, exit
 		if (interpreter->error.inError())
 		{
-			auto time = Now() - startTime;
+			const auto time = Now() - startTime;
 
 			shuttle->reply(
 				0, 
@@ -326,8 +328,7 @@ void OpenLoopCount::run()
 			// is there another query to run? If not we are done
 			if (!nextMacro())
 			{
-				
-				auto time = Now() - startTime;
+				const auto time = Now() - startTime;
 
 				openset::errors::Error error;
 

--- a/src/oloop_count.h
+++ b/src/oloop_count.h
@@ -25,7 +25,7 @@ namespace openset
 			openset::db::Table* table;
 			openset::db::TablePartitioned* parts;
 			int64_t maxLinearId;
-			int64_t currentLinId;
+			int32_t currentLinId;
 			Person person;
 			openset::query::Interpreter* interpreter;
 			int instance;

--- a/src/oloop_query.cpp
+++ b/src/oloop_query.cpp
@@ -114,7 +114,7 @@ void OpenLoopQuery::run()
 		// next set bit until there are no more, or maxLinId is met
 		if (interpreter->error.inError() || !index->linearIter(currentLinId, maxLinearId))
 		{
-			auto time = Now() - startTime;
+			const auto time = Now() - startTime;
 
 			shuttle->reply(
 				0, 

--- a/src/oloop_query.h
+++ b/src/oloop_query.h
@@ -25,7 +25,7 @@ namespace openset
 			openset::db::Table* table;
 			openset::db::TablePartitioned* parts;
 			int64_t maxLinearId;
-			int64_t currentLinId;
+			int32_t currentLinId;
 			Person person;
 			openset::query::Interpreter* interpreter;
 			int instance;

--- a/src/oloop_seg_refresh.h
+++ b/src/oloop_seg_refresh.h
@@ -24,7 +24,7 @@ namespace openset
 			openset::db::Table* table;
 
 			int64_t maxLinearId;
-			int64_t currentLinId;
+			int32_t currentLinId;
 			Person person;
 			openset::query::Interpreter* interpreter;
 			int instance;

--- a/src/queryinterpreter.cpp
+++ b/src/queryinterpreter.cpp
@@ -1852,7 +1852,10 @@ void openset::query::Interpreter::opRunner(Instruction_s* inst, int currentRow)
 								macros.vars.tableVars[inst->index].schemaColumn,
 								(*rows)[currentRow]->cols[macros.vars.tableVars[inst->index].column]);
 
-							*stackPtr = (attr && attr->text) ? attr->text : *stackPtr = (*rows)[currentRow]->cols[macros.vars.tableVars[inst->index].column];
+							if (attr && attr->text)
+								*stackPtr = attr->text;
+							else
+								*stackPtr = (*rows)[currentRow]->cols[macros.vars.tableVars[inst->index].column];
 						}
 						break;
 					default:

--- a/src/queryinterpreter.cpp
+++ b/src/queryinterpreter.cpp
@@ -1848,12 +1848,12 @@ void openset::query::Interpreter::opRunner(Instruction_s* inst, int currentRow)
 						break;
 					case columnTypes_e::textColumn:
 						{
-							const auto attr = grid->getAttributes()->get(
+							const auto text = grid->getAttributes()->blob->getValue(
 								macros.vars.tableVars[inst->index].schemaColumn,
 								(*rows)[currentRow]->cols[macros.vars.tableVars[inst->index].column]);
 
-							if (attr && attr->text)
-								*stackPtr = attr->text;
+							if (text)
+								*stackPtr = text;
 							else
 								*stackPtr = (*rows)[currentRow]->cols[macros.vars.tableVars[inst->index].column];
 						}

--- a/src/queryinterpreter.cpp
+++ b/src/queryinterpreter.cpp
@@ -105,6 +105,7 @@ void openset::query::Interpreter::mount(Person* person)
 
 	grid = person->getGrid(); // const
 	blob = grid->getAttributeBlob();
+	attrs = grid->getAttributes();
 	rows = grid->getRows(); // const
 	rowCount = rows->size();
 
@@ -1755,7 +1756,6 @@ bool openset::query::Interpreter::marshal(Instruction_s* inst, int& currentRow)
 		break;
 	case Marshals_e::marshal_range:
 		throw std::runtime_error("range is not implemented");
-		break;
 	case Marshals_e::marshal_url_decode:
 		marshal_url_decode(inst->extra);
 		break;
@@ -1848,14 +1848,11 @@ void openset::query::Interpreter::opRunner(Instruction_s* inst, int currentRow)
 						break;
 					case columnTypes_e::textColumn:
 						{
-							const auto text = grid->getAttributes()->blob->getValue(
+							const auto attr = attrs->get(
 								macros.vars.tableVars[inst->index].schemaColumn,
 								(*rows)[currentRow]->cols[macros.vars.tableVars[inst->index].column]);
 
-							if (text)
-								*stackPtr = text;
-							else
-								*stackPtr = (*rows)[currentRow]->cols[macros.vars.tableVars[inst->index].column];
+							*stackPtr = (attr && attr->text) ? attr->text : *stackPtr = (*rows)[currentRow]->cols[macros.vars.tableVars[inst->index].column];
 						}
 						break;
 					default:

--- a/src/queryinterpreter.h
+++ b/src/queryinterpreter.h
@@ -91,6 +91,7 @@ namespace openset
 			int rowCount{ 0 };
 
 			AttributeBlob* blob{ nullptr };
+			Attributes* attrs{ nullptr };
 			result::ResultSet* result{ nullptr };
 			result::RowKey rowKey;
 

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -8,9 +8,7 @@ using namespace openset::result;
 
 static char NA_TEXT[] = "n/a";
 
-ResultSet::ResultSet():
-	results(ringHint_e::lt_1_million),
-	localText(ringHint_e::lt_compact) 
+ResultSet::ResultSet()
 {}
 
 ResultSet::ResultSet(ResultSet&& other) noexcept:

--- a/src/result.h
+++ b/src/result.h
@@ -162,7 +162,7 @@ namespace openset
 		class ResultSet
 		{
 		public:
-			bigRing<RowKey, Accumulator*> results;
+			bigRing<RowKey, Accumulator*> results{ ringHint_e::lt_compact };
 			using RowPair = pair<RowKey, Accumulator*>;
 			using RowVector = vector<RowPair>;
 			vector<RowPair> sortedResult;			
@@ -176,7 +176,7 @@ namespace openset
 			// object will be populated
 			bool isPremerged = false;
 
-			bigRing<int64_t, char*> localText; // text local to result set
+			bigRing<int64_t, char*> localText{ ringHint_e::lt_compact }; // text local to result set
 
 			ResultSet();
 			ResultSet(ResultSet&& other) noexcept;

--- a/src/service.cpp
+++ b/src/service.cpp
@@ -13,7 +13,6 @@
 #include "uvserver.h"
 
 #include <thread>
-#include <chrono>
 
 namespace openset
 {
@@ -22,11 +21,11 @@ namespace openset
 
 	bool Service::start()
 	{
-		auto IP = globals::running->host;
-		auto port = globals::running->port;
-		auto pool = std::thread::hardware_concurrency() * 4; // set to number of cores
+		const auto IP = globals::running->host;
+		const auto port = globals::running->port;
+		const auto pool = std::thread::hardware_concurrency() * 2; // set to number of cores
 
-		auto partitionTotal = globals::running->partitionMax;
+		const auto partitionTotal = globals::running->partitionMax;
 
 #ifndef _MSC_VER
 		signal(SIGPIPE, SIG_IGN);

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -4,7 +4,6 @@
 #include "table.h"
 #include "queryparser.h"
 #include "indexbits.h"
-#include "cjson/cjson.h"
 #include "config.h"
 #include "file/file.h"
 
@@ -88,14 +87,14 @@ void Trigger::init()
 	interpreter = new openset::query::Interpreter(macros, openset::query::InterpretMode_e::job);
 
 	// This is the text value for this triggers on_insert event
-	auto valueName = settings->name + "::on_insert";
+	const auto valueName = settings->name + "::on_insert";
 
 	settings->id = MakeHash(valueName);
 
 	// get our index bits if we have any. We will be keeping these cached
 	attr = parts->attributes.getMake(COL_TRIGGERS, valueName);
 	bits = new IndexBits();
-	bits->mount(attr->index, attr->ints);
+	bits->mount(attr->index, attr->ints, attr->linId);
 
 	// this call back will be called by the 'schedule' marshal in the interpretor
 	auto schedule_cb = [&](int64_t functionHash, int seconds) -> bool
@@ -169,21 +168,21 @@ void Trigger::flushDirty()
 	*/
 
 	int64_t compBytes = 0; // OUT value via reference filled by ->store
-	auto compData = bits->store(compBytes);
+	int32_t linId = -1;
+	const auto compData = bits->store(compBytes, linId);
 
-
-
-	auto columnIndex = parts->attributes.getColumnIndex(COL_TRIGGERS); // 4 is triggers
+	const auto columnIndex = parts->attributes.getColumnIndex(COL_TRIGGERS); // 4 is triggers
 	auto attrPair = columnIndex->find(settings->id); // settings.id is this trigger
 
-	auto oldAttr = attrPair->second; // keep it so we can delete it.
+	const auto oldAttr = attrPair->second; // keep it so we can delete it.
 
-	auto newAttr = recast<Attr_s*>(
+	const auto newAttr = recast<Attr_s*>(
 		PoolMem::getPool().getPtr(sizeof(Attr_s) + compBytes));
 
 	// copy header
 	std::memcpy(newAttr, oldAttr, sizeof(Attr_s));
 	std::memcpy(newAttr->index, compData, compBytes);
+	newAttr->linId = linId;
 
 	// swap old index
 	attrPair->second = newAttr;
@@ -229,7 +228,7 @@ void Trigger::postInsertTest()
 		bits->bitSet(person->getMeta()->linId);
 }
 
-bool Trigger::runFunction(int64_t functionHash)
+bool Trigger::runFunction(const int64_t functionHash)
 {
 	checkReload();
 

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -127,8 +127,8 @@ void Trigger::init()
 
 		// flip some bits when we emits - these will get flushed by the 
 		// standard dirty write back on insert
-		auto emitAttr = parts->attributes.getMake(5, emitMessage);
-		emitAttr->addChange(person->getMeta()->linId, true);
+		auto emitAttr = parts->attributes.getMake(COL_EMIT, emitMessage);
+		parts->attributes.addChange(COL_EMIT, MakeHash(emitMessage), person->getMeta()->linId, true);
 
 		// queue trigger messages, these are held on a per trigger basis
 		// these are shuttled out to a master queue at some point
@@ -171,8 +171,7 @@ void Trigger::flushDirty()
 	int32_t linId = -1;
 	const auto compData = bits->store(compBytes, linId);
 
-	const auto columnIndex = parts->attributes.getColumnIndex(COL_TRIGGERS); // 4 is triggers
-	auto attrPair = columnIndex->find(settings->id); // settings.id is this trigger
+	auto attrPair = parts->attributes.columnIndex.find({ COL_TRIGGERS, settings->id }); // settings.id is this trigger
 
 	const auto oldAttr = attrPair->second; // keep it so we can delete it.
 

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -186,7 +186,7 @@ namespace openset
 			void preInsertTest();
 			void postInsertTest();
 
-			bool runFunction(int64_t functionHash);
+			bool runFunction(const int64_t functionHash);
 
 			std::string getName() const
 			{


### PR DESCRIPTION
Completely sparse indexes (where one attributes maps to one user, i.e. an email address, or even a custom URL) would waste lots of space in larger datasets. 

Downside is Attribute records use 4 more bytes, and it would be interesting to revisit this with a more aggressive `user list` or `compressed bits` depending on which is best.