### PR TITLE
Fix-up dead links in the README and touch .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,8 @@ $RECYCLE.BIN/
 # Directories potentially created on remote AFP share
 .AppleDB
 .AppleDesktop
-Network Trash Folder
-Temporary Items
+"Network Trash Folder"
+"Temporary Items"
 .apdisk
 Debug
 x64

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ OpenSet can be clustered so you can scale for performance and redundancy.
 
 # Links
 
--   [Documentation](https://github.com/perple-io/openset/tree/master/docs)
--   [Docker Images](https://github.com/perple-io/openset/tree/master/docs/docker)
+-   [Documentation](https://github.com/opset/openset/tree/master/docs)
+-   [Docker Images](https://github.com/opset/openset/tree/master/docs/docker)
 
 # Examples using curl
 
@@ -143,7 +143,7 @@ response:
 }
 ```
 
-> :bulb: view the event data [here](https://github.com/perple-io/openset/blob/master/samples/data/highstreet_events.json)
+> :bulb: view the event data [here](https://github.com/opset/openset_samples/blob/master/data/highstreet_events.json)
 
 **7. Let's perform an `event` query.**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,11 +5,11 @@
 **topics**
 
 * [Docker Images](https://github.com/opset/openset/tree/master/docs/docker) (recommended - run anywhere)
-* [Building and Installing](https://github.com/perple-io/openset/tree/master/docs/build_install)  (build release or debug on windows or linux)
-* [OSL query language overview](https://github.com/perple-io/openset/tree/master/docs/osl/README.md)
-* [OSL language reference](https://github.com/perple-io/openset/blob/master/docs/osl/language_reference.md)
-* [REST API](https://github.com/perple-io/openset/tree/master/docs/rest/README.md)
+* [Building and Installing](https://github.com/opset/openset/tree/master/docs/build_install)  (build release or debug on windows or linux)
+* [OSL query language overview](https://github.com/opset/openset/tree/master/docs/osl/README.md)
+* [OSL language reference](https://github.com/opset/openset/blob/master/docs/osl/language_reference.md)
+* [REST API](https://github.com/opset/openset/tree/master/docs/rest/README.md)
 * [Samples](https://github.com/opset/openset_samples)  
 * [Clustering](#) (coming soon)
 
-:coffee: These documents are a work in progress. 
+:coffee: These documents are a work in progress.

--- a/docs/build_install/README.md
+++ b/docs/build_install/README.md
@@ -10,7 +10,7 @@ OpenSet incorporates the following amazing and wonderful open source projects:
 - [lz4](https://github.com/lz4/lz4), the extremely fast compression/decompression library by Yann Collet. Event data and Indexes are compressed in OpenSet. Compression allows us to store 10x the data (or more) while realizing a < 10% performance impact (see the [benchmark](https://github.com/lz4/lz4#benchmarks) on GitHub)
 - [xxHash](https://github.com/Cyan4973/xxHash), another masterpiece by  Yann Collet. A good hash is hard to find, a fast hash is even harder --- Yann has created both.
 
-You will find recent versions of these projects under [openset/vendor](https://github.com/perple-io/openset/tree/master/vendor) in the OpenSet repo.
+You will find recent versions of these projects under [openset/vendor](https://github.com/opset/openset/tree/master/vendor) in the OpenSet repo.
 
 #### Linux requirements
 
@@ -20,7 +20,7 @@ You will find recent versions of these projects under [openset/vendor](https://g
 - GDB 7+ (optional)
 - Node.js 5+ (optional for running samples)
 
-> :pushpin: passing `--version` to these tools on the command line will help you verify they are the correct version.  If you need to install these please read the **[build tools](https://github.com/perple-io/openset/blob/master/docs/build_install/build_tools.md)** document.
+> :pushpin: passing `--version` to these tools on the command line will help you verify they are the correct version.  If you need to install these please read the **[build tools](https://github.com/opset/openset/blob/master/docs/build_install/build_tools.md)** document.
 
 #### Windows requirements
 
@@ -35,7 +35,7 @@ You will find recent versions of these projects under [openset/vendor](https://g
 ```bash
 mkdir openset
 cd openset
-git clone --recursive https://github.com/perple-io/openset.git 
+git clone --recursive https://github.com/opset/openset.git
 ```
 3. build OpenSet release:
 ```bash
@@ -63,7 +63,7 @@ You will need Visual Studio 2017 version 15.4.x (or higher).
 ```bash
 mkdir openset
 cd openset
-git clone --recursive https://github.com/perple-io/openset.git 
+git clone --recursive https://github.com/opset/openset.git
 ```
 1. Open the `openset` folder in Visual Studio
 2. Open the file `CMakeList.txt`, wait for Visual Studio to index it.

--- a/docs/osl/README.md
+++ b/docs/osl/README.md
@@ -8,7 +8,7 @@ Likewise, many of the cooler features in Ruby and Python are not included in OSL
 
 OSL queries are compiled into op codes and executed. In addition to being compiled the logic identified in a query is analyzed to optimize the query, this is why OSL uses chain functions such as `.within()` or `.ever()` to make clear intent of the logic.
 
-You can find the language reference [here](https://github.com/perple-io/openset/blob/master/docs/osl/language_reference.md).
+You can find the language reference [here](https://github.com/opset/openset/blob/master/docs/osl/language_reference.md).
 
 # Anatomy of an OpenSet query
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -16,7 +16,7 @@ npm install
 | :----------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |        `init_cluster.js` | OpenSet starts in standby mode awaiting a role. You must make one node leader to start a cluster. Even if you intend to run a single node installation, you must initialize the cluster                                                    |
 |        `invite_node.js`  | To add more freshly started nodes (in standby) to an initialized cluster.                                                                                                                                                                  |
-|        `create_table.js` | Creates a table. This requires that you provide a JSON input file containing the table definition. There is an example [here]](https://github.com/perple-io/openset/blob/master/samples/pyql/highstreet_table.json)                        |
+|        `create_table.js` | Creates a table. This requires that you provide a JSON input file containing the table definition. There is an example [here]](https://github.com/opset/openset/blob/master/samples/pyql/highstreet_table.json)                        |
 |        `insert_json.js`  | A bulk import tool. You provide a directory containing JSON files. The files must have one JSON document per line, each line must define an event. Note: if your file names sort numerically they will be imported from lowest to highest. |
 
 


### PR DESCRIPTION
There are a couple links that point to perple-io rather than opset.  I'll update this PR to get the rest from the README.